### PR TITLE
Add helper plugin to enforce support hub styling

### DIFF
--- a/gaenity-community/README.md
+++ b/gaenity-community/README.md
@@ -1,0 +1,61 @@
+# Gaenity Support Hub
+
+Elegant, one-page community hub for Gaenity entrepreneurs and experts. The plugin delivers a polished landing experience with resource highlights, curated discussions, polls, chat, and onboarding forms—all available through shortcodes or an Elementor widget. Styling inherits the active theme while layering refined layout enhancements.
+
+## Requirements
+
+- WordPress 6.1 or newer (tested up to 6.5)
+- PHP 7.4 or newer
+- Elementor (optional) 3.7+ for the bundled widget
+
+## Installation
+
+1. Upload the `gaenity-community` directory to `wp-content/plugins/` or install it via the WordPress plugin uploader.
+2. Activate **Gaenity Support Hub**. The plugin automatically creates a “Gaenity Support Hub” page containing the main shortcode.
+3. Adjust the content or move the `[gaenity_support_hub]` shortcode to any page or Elementor template as needed.
+
+## Shortcodes
+
+| Shortcode | Purpose |
+| --- | --- |
+| `[gaenity_support_hub]` | Full one-page experience containing hero, discussions, resources, polls, experts, registration, login, chat, and contact sections. |
+| `[gaenity_community block="community_home"]` | Outputs only the community discovery section with tabs and featured discussions. |
+| `[gaenity_register]` | Displays the registration form with demo select options. |
+| `[gaenity_login]` | Renders the sign-in form. |
+| `[gaenity_chat]` | Renders the demo chat feed and quick post form. |
+
+Each shortcode automatically loads the curated styles (`assets/css/support-hub.css`) and interactivity (`assets/js/support-hub.js`).
+
+## Elementor
+
+After activating the plugin, search for **Gaenity Support Hub** within Elementor’s widget panel. Drag it onto a layout to render the full shortcode without additional configuration. The widget simply wraps the `[gaenity_support_hub]` shortcode so all settings remain centralised.
+
+## Demo Content
+
+The plugin seeds polished placeholder data so that every section feels alive immediately after activation:
+
+- Five featured discussions spanning multiple regions and focus areas
+- Five downloadable resource summaries
+- Five highlighted experts with focus tags and action buttons
+- Three live poll cards with percentage breakdowns
+- Five recent chat messages (including anonymous contributors)
+
+Edit any copy by overriding the shortcode output or replacing the auto-created page with your own Elementor design.
+
+## Styling
+
+The CSS keeps typography and global colours inherited from the current theme. Utility custom properties provide subtle shadows, rounded corners, and responsive spacing. Feel free to override the `.gaenity-support-hub` selectors in your theme or child-theme stylesheet for bespoke branding.
+
+## Troubleshooting
+
+- **Missing styling** – Ensure the theme calls `wp_head()` and `wp_footer()` so the enqueued assets load. The plugin defers CSS/JS until a shortcode or the Elementor widget renders.
+- **Duplicate landing page** – Delete or unpublish the generated page and place the shortcode on your desired page.
+- **Elementor widget not visible** – Confirm Elementor is active, then use the search bar to locate “Gaenity Support Hub” under the *General* category.
+
+## Changelog
+
+### 3.0.0
+- Rebuilt the plugin as a single-page support experience with refreshed shortcodes
+- Added professional, responsive styling that inherits theme typography
+- Bundled Elementor widget wrapper and automatic page seeding
+- Populated demo discussions, resources, experts, polls, and chat feed for immediate context

--- a/gaenity-community/assets/css/support-hub.css
+++ b/gaenity-community/assets/css/support-hub.css
@@ -1,0 +1,510 @@
+:root {
+    --gaenity-color-primary: #1e4dd8;
+    --gaenity-color-primary-soft: rgba(30, 77, 216, 0.12);
+    --gaenity-color-surface: #ffffff;
+    --gaenity-color-muted: #6a6f85;
+    --gaenity-color-border: rgba(15, 23, 42, 0.12);
+    --gaenity-radius-large: 24px;
+    --gaenity-radius-medium: 16px;
+    --gaenity-radius-small: 10px;
+    --gaenity-shadow-soft: 0 20px 45px -25px rgba(15, 23, 42, 0.45);
+    --gaenity-gap: clamp(1.5rem, 2vw, 2.25rem);
+}
+
+.gaenity-support-hub,
+.gaenity-support-hub * {
+    box-sizing: border-box;
+}
+
+.gaenity-support-hub {
+    font-family: inherit;
+}
+
+.gaenity-support-hub a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.gaenity-support-hub__hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--gaenity-gap);
+    padding: clamp(3rem, 6vw, 5rem);
+    background: linear-gradient(135deg, rgba(30, 77, 216, 0.08), rgba(30, 77, 216, 0.22));
+    border-radius: var(--gaenity-radius-large);
+    margin-bottom: clamp(3rem, 6vw, 4rem);
+}
+
+.gaenity-support-hub__hero-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.gaenity-support-hub__eyebrow {
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(30, 31, 73, 0.7);
+}
+
+.gaenity-support-hub__headline {
+    margin: 0;
+    font-size: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.gaenity-support-hub__intro {
+    margin: 0;
+    color: var(--gaenity-color-muted);
+    font-size: 1.1rem;
+    max-width: 42ch;
+}
+
+.gaenity-support-hub__hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.gaenity-support-hub__hero-panel {
+    background: var(--gaenity-color-surface);
+    border-radius: var(--gaenity-radius-medium);
+    padding: 2rem;
+    box-shadow: var(--gaenity-shadow-soft);
+    align-self: stretch;
+}
+
+.gaenity-support-hub__hero-highlights {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.gaenity-support-hub__highlight-label {
+    display: block;
+    color: var(--gaenity-color-muted);
+    font-size: 0.9rem;
+}
+
+.gaenity-support-hub__highlight-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+}
+
+.gaenity-support-hub__section {
+    margin-bottom: clamp(3rem, 6vw, 4.5rem);
+}
+
+.gaenity-support-hub__section-header {
+    display: grid;
+    gap: 0.75rem;
+    margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+    max-width: 720px;
+}
+
+.gaenity-support-hub__section-header h2 {
+    margin: 0;
+    font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.gaenity-support-hub__section-header p {
+    margin: 0;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__notice {
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    background: rgba(30, 77, 216, 0.12);
+    color: #1b2556;
+    font-weight: 600;
+}
+
+.gaenity-support-hub__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.75rem;
+    background: var(--gaenity-color-primary);
+    color: #fff;
+    border-radius: 999px;
+    border: none;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gaenity-support-hub__btn:hover,
+.gaenity-support-hub__btn:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 18px -12px rgba(30, 77, 216, 0.65);
+}
+
+.gaenity-support-hub__btn--ghost {
+    background: rgba(30, 77, 216, 0.12);
+    color: #1e2a5a;
+}
+
+.gaenity-support-hub__btn--subtle {
+    background: transparent;
+    color: var(--gaenity-color-primary);
+    border: 1px solid rgba(30, 77, 216, 0.2);
+}
+
+.gaenity-support-hub__resource-grid,
+.gaenity-support-hub__discussion-grid,
+.gaenity-support-hub__poll-grid,
+.gaenity-support-hub__expert-grid {
+    display: grid;
+    gap: var(--gaenity-gap);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.gaenity-support-hub__resource-card,
+.gaenity-support-hub__discussion-card,
+.gaenity-support-hub__poll-card,
+.gaenity-support-hub__expert-card {
+    background: var(--gaenity-color-surface);
+    border-radius: var(--gaenity-radius-medium);
+    padding: clamp(1.5rem, 3vw, 2rem);
+    border: 1px solid var(--gaenity-color-border);
+    box-shadow: 0 12px 35px -30px rgba(15, 23, 42, 0.7);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 100%;
+}
+
+.gaenity-support-hub__resource-illustration {
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    display: grid;
+    place-items: center;
+    font-size: 1.75rem;
+    background: var(--gaenity-color-primary-soft);
+}
+
+.gaenity-support-hub__resource-card h3,
+.gaenity-support-hub__discussion-card h3,
+.gaenity-support-hub__poll-card h3,
+.gaenity-support-hub__expert-card h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.gaenity-support-hub__resource-card p,
+.gaenity-support-hub__discussion-card p,
+.gaenity-support-hub__poll-card p,
+.gaenity-support-hub__expert-card p {
+    margin: 0;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(30, 77, 216, 0.15);
+    color: #1d2d50;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.gaenity-support-hub__badge--ghost {
+    background: rgba(15, 23, 42, 0.06);
+    color: #364152;
+}
+
+.gaenity-support-hub__badge--accent {
+    background: rgba(255, 174, 0, 0.16);
+    color: #8a5800;
+}
+
+.gaenity-support-hub__discussion-meta {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.gaenity-support-hub__discussion-footer {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    color: var(--gaenity-color-muted);
+    font-size: 0.9rem;
+}
+
+.gaenity-support-hub__meta-divider {
+    opacity: 0.6;
+}
+
+.gaenity-support-hub__avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background: rgba(30, 77, 216, 0.18);
+    display: grid;
+    place-items: center;
+    font-size: 0.9rem;
+}
+
+.gaenity-support-hub__tabs {
+    display: inline-flex;
+    border-radius: 999px;
+    padding: 0.4rem;
+    background: rgba(15, 23, 42, 0.05);
+    margin-bottom: 1.5rem;
+}
+
+.gaenity-support-hub__tab {
+    border: none;
+    background: transparent;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--gaenity-color-muted);
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.gaenity-support-hub__tab.is-active {
+    background: #fff;
+    color: #172554;
+    box-shadow: 0 10px 20px -15px rgba(15, 23, 42, 0.55);
+}
+
+.gaenity-support-hub__tab-panels {
+    position: relative;
+}
+
+.gaenity-support-hub__tab-panel {
+    display: none;
+    padding: 0.5rem 0;
+}
+
+.gaenity-support-hub__tab-panel.is-active {
+    display: block;
+}
+
+.gaenity-support-hub__tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.gaenity-support-hub__form {
+    background: var(--gaenity-color-surface);
+    border-radius: var(--gaenity-radius-medium);
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    border: 1px solid var(--gaenity-color-border);
+    box-shadow: 0 15px 35px -32px rgba(15, 23, 42, 0.55);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.gaenity-support-hub__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.gaenity-support-hub__field {
+    display: grid;
+    gap: 0.4rem;
+}
+
+.gaenity-support-hub__field--full {
+    grid-column: 1 / -1;
+}
+
+.gaenity-support-hub__field span,
+.gaenity-support-hub__choice span {
+    font-weight: 600;
+    color: #1a1f2d;
+}
+
+.gaenity-support-hub__field input,
+.gaenity-support-hub__field select,
+.gaenity-support-hub__field textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(15, 23, 42, 0.18);
+    background: rgba(248, 250, 255, 0.75);
+    font: inherit;
+    color: inherit;
+}
+
+.gaenity-support-hub__field textarea {
+    resize: vertical;
+}
+
+.gaenity-support-hub__choice {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-size: 0.95rem;
+}
+
+.gaenity-support-hub__choice input {
+    width: 1.1rem;
+    height: 1.1rem;
+}
+
+.gaenity-support-hub__form-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.gaenity-support-hub__link {
+    color: var(--gaenity-color-primary);
+    font-weight: 600;
+}
+
+.gaenity-support-hub__form-notice {
+    margin: 0;
+    color: var(--gaenity-color-primary);
+    font-weight: 600;
+    display: none;
+}
+
+.gaenity-support-hub__form-notice.is-visible {
+    display: block;
+}
+
+.gaenity-support-hub__chat {
+    display: grid;
+    gap: var(--gaenity-gap);
+}
+
+.gaenity-support-hub__chat-feed {
+    max-height: 320px;
+    overflow-y: auto;
+    display: grid;
+    gap: 1rem;
+    padding-right: 0.5rem;
+}
+
+.gaenity-support-hub__chat-message {
+    padding: 1rem 1.25rem;
+    border-radius: var(--gaenity-radius-small);
+    background: rgba(248, 250, 255, 0.85);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 0.35rem;
+}
+
+.gaenity-support-hub__chat-meta {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__poll-options {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.gaenity-support-hub__poll-options li {
+    display: grid;
+    gap: 0.3rem;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__progress {
+    display: block;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(30, 77, 216, 0.18);
+    position: relative;
+}
+
+.gaenity-support-hub__progress::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--gaenity-color-primary);
+    transform: scaleX(calc(var(--gaenity-progress) / 100));
+    transform-origin: left;
+}
+
+.gaenity-support-hub__expert-avatar {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: rgba(30, 77, 216, 0.15);
+    font-size: 1.5rem;
+    align-self: flex-start;
+}
+
+.gaenity-support-hub__expert-role {
+    font-weight: 600;
+    color: #1a1f2d;
+}
+
+.gaenity-support-hub__expert-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.gaenity-support-hub__expert-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: auto;
+}
+
+.gaenity-support-hub__social {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__social a {
+    color: var(--gaenity-color-primary);
+    font-weight: 600;
+}
+
+@media (max-width: 640px) {
+    .gaenity-support-hub__hero {
+        padding: 2.5rem;
+    }
+
+    .gaenity-support-hub__hero-panel {
+        padding: 1.5rem;
+    }
+
+    .gaenity-support-hub__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .gaenity-support-hub__hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/gaenity-community/assets/js/support-hub.js
+++ b/gaenity-community/assets/js/support-hub.js
@@ -1,0 +1,73 @@
+(function ($) {
+    'use strict';
+
+    const selectors = {
+        tab: '[data-gaenity-tab]',
+        tabPanel: '.gaenity-support-hub__tab-panel',
+        form: '.gaenity-support-hub__form',
+    };
+
+    function activateTab($button) {
+        const target = $button.data('gaenity-tab');
+
+        $button
+            .addClass('is-active')
+            .attr({
+                'aria-selected': 'true',
+                tabindex: '0',
+            })
+            .siblings()
+            .removeClass('is-active')
+            .attr({
+                'aria-selected': 'false',
+                tabindex: '-1',
+            });
+
+        $button
+            .closest('.gaenity-support-hub__section')
+            .find(selectors.tabPanel)
+            .removeClass('is-active')
+            .attr('hidden', true)
+            .filter('#gaenity-tab-' + target)
+            .addClass('is-active')
+            .removeAttr('hidden');
+    }
+
+    function bindTabs($context) {
+        $context.on('click keydown', selectors.tab, function (event) {
+            if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') {
+                return;
+            }
+
+            event.preventDefault();
+            activateTab($(this));
+        });
+
+        $context.find(selectors.tab).first().trigger('click');
+    }
+
+    function bindForms($context) {
+        $context.on('submit', selectors.form, function (event) {
+            event.preventDefault();
+            const $form = $(this);
+            const message = $form.data('success') || 'Submission received!';
+            const $notice = $form.find('.gaenity-support-hub__form-notice');
+
+            if ($notice.length) {
+                $notice.text(message).addClass('is-visible');
+            }
+
+            this.reset();
+        });
+    }
+
+    $(function () {
+        const $hub = $('[data-gaenity-component="support-hub"]');
+
+        if ($hub.length) {
+            bindTabs($hub);
+        }
+
+        bindForms($(document));
+    });
+})(jQuery);

--- a/gaenity-community/gaenity-community.php
+++ b/gaenity-community/gaenity-community.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Gaenity Support Hub
+ * Description: Elegant one-page community and resource hub with polished styling and Elementor/shortcode support for the Gaenity network.
+ * Version: 3.0.0
+ * Author: skillscore IT solutions and training
+ * Text Domain: gaenity-community
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'GAENITY_SUPPORT_HUB_FILE', __FILE__ );
+define( 'GAENITY_SUPPORT_HUB_PATH', plugin_dir_path( __FILE__ ) );
+define( 'GAENITY_SUPPORT_HUB_URL', plugin_dir_url( __FILE__ ) );
+require_once GAENITY_SUPPORT_HUB_PATH . 'includes/class-gaenity-support-hub.php';
+
+Gaenity_Support_Hub::instance();
+
+register_activation_hook( __FILE__, array( 'Gaenity_Support_Hub', 'activate' ) );
+register_deactivation_hook( __FILE__, array( 'Gaenity_Support_Hub', 'deactivate' ) );

--- a/gaenity-community/includes/class-gaenity-support-hub-elementor-widget.php
+++ b/gaenity-community/includes/class-gaenity-support-hub-elementor-widget.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Elementor widget wrapper for the Gaenity Support Hub shortcode.
+ *
+ * @package GaenitySupportHub
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( class_exists( '\\Elementor\\Widget_Base' ) ) {
+    /**
+     * Simple Elementor widget to output the hub shortcode.
+     */
+    class Gaenity_Support_Hub_Elementor_Widget extends \Elementor\Widget_Base {
+
+        /**
+         * Widget name.
+         */
+        public function get_name() {
+            return 'gaenity-support-hub';
+        }
+
+        /**
+         * Widget title.
+         */
+        public function get_title() {
+            return __( 'Gaenity Support Hub', 'gaenity-community' );
+        }
+
+        /**
+         * Widget icon.
+         */
+        public function get_icon() {
+            return 'eicon-site-title';
+        }
+
+        /**
+         * Widget categories.
+         */
+        public function get_categories() {
+            return array( 'general' );
+        }
+
+        /**
+         * Render widget output.
+         */
+        protected function render() {
+            echo do_shortcode( '[gaenity_support_hub]' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
+    }
+}

--- a/gaenity-community/includes/class-gaenity-support-hub.php
+++ b/gaenity-community/includes/class-gaenity-support-hub.php
@@ -1,0 +1,976 @@
+<?php
+/**
+ * Core loader for the Gaenity Support Hub plugin.
+ *
+ * @package GaenitySupportHub
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Main plugin class.
+ */
+class Gaenity_Support_Hub {
+
+    /**
+     * Plugin version.
+     */
+    const VERSION = '3.0.0';
+
+    /**
+     * Option key for landing page.
+     *
+     * @var string
+     */
+    const PAGE_OPTION = 'gaenity_support_hub_page_id';
+
+    /**
+     * Singleton instance.
+     *
+     * @var Gaenity_Support_Hub|null
+     */
+    protected static $instance = null;
+
+    /**
+     * Retrieve singleton instance.
+     *
+     * @return Gaenity_Support_Hub
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+            self::$instance->setup_hooks();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Activation callback.
+     */
+    public static function activate() {
+        $page_id = (int) get_option( self::PAGE_OPTION );
+
+        if ( $page_id && 'page' === get_post_type( $page_id ) ) {
+            return;
+        }
+
+        $page_args = array(
+            'post_title'   => __( 'Gaenity Support Hub', 'gaenity-community' ),
+            'post_content' => '[gaenity_support_hub]',
+            'post_status'  => 'publish',
+            'post_type'    => 'page',
+        );
+
+        $page_id = wp_insert_post( $page_args );
+
+        if ( $page_id && ! is_wp_error( $page_id ) ) {
+            update_option( self::PAGE_OPTION, (int) $page_id );
+        }
+    }
+
+    /**
+     * Deactivation callback.
+     */
+    public static function deactivate() {
+        $page_id = (int) get_option( self::PAGE_OPTION );
+
+        if ( $page_id && 'page' === get_post_type( $page_id ) ) {
+            wp_trash_post( $page_id );
+        }
+
+        delete_option( self::PAGE_OPTION );
+    }
+
+    /**
+     * Hook registration.
+     */
+    protected function setup_hooks() {
+        add_action( 'init', array( $this, 'register_shortcodes' ) );
+        add_action( 'wp_enqueue_scripts', array( $this, 'register_assets' ) );
+        add_filter( 'plugin_action_links_' . plugin_basename( GAENITY_SUPPORT_HUB_FILE ), array( $this, 'action_links' ) );
+        add_action( 'elementor/widgets/register', array( $this, 'register_elementor_widget' ) );
+    }
+
+    /**
+     * Register scripts and styles.
+     */
+    public function register_assets() {
+        wp_register_style(
+            'gaenity-support-hub',
+            GAENITY_SUPPORT_HUB_URL . 'assets/css/support-hub.css',
+            array(),
+            self::VERSION
+        );
+
+        wp_register_script(
+            'gaenity-support-hub',
+            GAENITY_SUPPORT_HUB_URL . 'assets/js/support-hub.js',
+            array( 'jquery' ),
+            self::VERSION,
+            true
+        );
+    }
+
+    /**
+     * Add helpful plugin action links.
+     *
+     * @param array $links Existing links.
+     *
+     * @return array
+     */
+    public function action_links( $links ) {
+        $page_id = (int) get_option( self::PAGE_OPTION );
+
+        if ( $page_id ) {
+            $links[] = '<a href="' . esc_url( get_edit_post_link( $page_id ) ) . '">' . esc_html__( 'Edit Support Hub Page', 'gaenity-community' ) . '</a>';
+        }
+
+        $links[] = '<a href="https://gaenity.com" target="_blank" rel="noopener">' . esc_html__( 'Need help?', 'gaenity-community' ) . '</a>';
+
+        return $links;
+    }
+
+    /**
+     * Register Elementor widget wrapper if Elementor is active.
+     */
+    public function register_elementor_widget( $widgets_manager ) {
+        if ( ! class_exists( '\\Elementor\\Widget_Base' ) ) {
+            return;
+        }
+
+        if ( ! class_exists( 'Gaenity_Support_Hub_Elementor_Widget', false ) ) {
+            require_once GAENITY_SUPPORT_HUB_PATH . 'includes/class-gaenity-support-hub-elementor-widget.php';
+        }
+
+        $widgets_manager->register( new Gaenity_Support_Hub_Elementor_Widget() );
+    }
+
+    /**
+     * Register plugin shortcodes.
+     */
+    public function register_shortcodes() {
+        add_shortcode( 'gaenity_support_hub', array( $this, 'render_support_hub' ) );
+        add_shortcode( 'gaenity_community', array( $this, 'render_community_block' ) );
+        add_shortcode( 'gaenity_register', array( $this, 'render_register_block' ) );
+        add_shortcode( 'gaenity_login', array( $this, 'render_login_block' ) );
+        add_shortcode( 'gaenity_chat', array( $this, 'render_chat_block' ) );
+    }
+
+    /**
+     * Ensure scripts and styles are loaded.
+     */
+    protected function enqueue_assets() {
+        wp_enqueue_style( 'gaenity-support-hub' );
+        wp_enqueue_script( 'gaenity-support-hub' );
+    }
+
+    /**
+     * Render the one-page experience.
+     *
+     * @return string
+     */
+    public function render_support_hub() {
+        $this->enqueue_assets();
+
+        ob_start();
+        ?>
+        <div class="gaenity-support-hub" data-gaenity-component="support-hub">
+            <?php echo $this->render_hero(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_community_block( array( 'block' => 'community_home' ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_resources_section(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_polls_section(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_experts_section(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_register_block(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_login_block(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_chat_block(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php echo $this->render_contact_section(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        </div>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render hero section.
+     *
+     * @return string
+     */
+    protected function render_hero() {
+        $this->enqueue_assets();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__hero">
+            <div class="gaenity-support-hub__hero-content">
+                <p class="gaenity-support-hub__eyebrow"><?php esc_html_e( 'Community & Enablement', 'gaenity-community' ); ?></p>
+                <h1 class="gaenity-support-hub__headline"><?php esc_html_e( 'Gaenity Support Hub', 'gaenity-community' ); ?></h1>
+                <p class="gaenity-support-hub__intro"><?php esc_html_e( 'A polished, one-stop community portal for entrepreneurs, professionals, and experts to collaborate, learn, and grow.', 'gaenity-community' ); ?></p>
+                <div class="gaenity-support-hub__hero-actions">
+                    <a class="gaenity-support-hub__btn" href="#gaenity-register"><?php esc_html_e( 'Join the Community', 'gaenity-community' ); ?></a>
+                    <a class="gaenity-support-hub__btn gaenity-support-hub__btn--ghost" href="#gaenity-resources"><?php esc_html_e( 'Browse Resources', 'gaenity-community' ); ?></a>
+                </div>
+            </div>
+            <div class="gaenity-support-hub__hero-panel">
+                <ul class="gaenity-support-hub__hero-highlights">
+                    <li>
+                        <span class="gaenity-support-hub__highlight-label"><?php esc_html_e( 'Members', 'gaenity-community' ); ?></span>
+                        <span class="gaenity-support-hub__highlight-value">5,200+</span>
+                    </li>
+                    <li>
+                        <span class="gaenity-support-hub__highlight-label"><?php esc_html_e( 'Expert Sessions Delivered', 'gaenity-community' ); ?></span>
+                        <span class="gaenity-support-hub__highlight-value">940</span>
+                    </li>
+                    <li>
+                        <span class="gaenity-support-hub__highlight-label"><?php esc_html_e( 'Resources Downloaded', 'gaenity-community' ); ?></span>
+                        <span class="gaenity-support-hub__highlight-value">12k</span>
+                    </li>
+                </ul>
+            </div>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render community block based on attribute.
+     *
+     * @param array|string $atts Attributes.
+     *
+     * @return string
+     */
+    public function render_community_block( $atts = array() ) {
+        $this->enqueue_assets();
+
+        $atts = shortcode_atts(
+            array(
+                'block' => 'community_home',
+            ),
+            $atts,
+            'gaenity_community'
+        );
+
+        if ( 'community_home' !== $atts['block'] ) {
+            return '<div class="gaenity-support-hub__notice">' . esc_html__( 'This community block is not available yet. Displaying the community home instead.', 'gaenity-community' ) . '</div>' . $this->render_community_block( array( 'block' => 'community_home' ) );
+        }
+
+        $demo_discussions = $this->get_demo_discussions();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-community">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Community Home', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'Connect with peers in your region or industry, share challenges, and access curated discussions.', 'gaenity-community' ); ?></p>
+            </header>
+            <div class="gaenity-support-hub__tabs" role="tablist">
+                <?php
+                $tabs = array(
+                    'regions'     => __( 'Regions', 'gaenity-community' ),
+                    'industries'  => __( 'Industries', 'gaenity-community' ),
+                    'challenges'  => __( 'Common Challenges', 'gaenity-community' ),
+                );
+                foreach ( $tabs as $slug => $label ) :
+                    ?>
+                    <button class="gaenity-support-hub__tab" type="button" role="tab" data-gaenity-tab="<?php echo esc_attr( $slug ); ?>">
+                        <?php echo esc_html( $label ); ?>
+                    </button>
+                    <?php
+                endforeach;
+                ?>
+            </div>
+            <div class="gaenity-support-hub__tab-panels">
+                <?php echo $this->render_tab_panel( 'regions', $this->get_demo_regions() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                <?php echo $this->render_tab_panel( 'industries', $this->get_demo_industries() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+                <?php echo $this->render_tab_panel( 'challenges', $this->get_demo_challenges() ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            </div>
+            <div class="gaenity-support-hub__discussion-grid">
+                <?php foreach ( $demo_discussions as $discussion ) : ?>
+                    <article class="gaenity-support-hub__discussion-card">
+                        <div class="gaenity-support-hub__discussion-meta">
+                            <span class="gaenity-support-hub__badge"><?php echo esc_html( $discussion['topic'] ); ?></span>
+                            <span class="gaenity-support-hub__badge gaenity-support-hub__badge--ghost"><?php echo esc_html( $discussion['region'] ); ?></span>
+                        </div>
+                        <h3><?php echo esc_html( $discussion['title'] ); ?></h3>
+                        <p><?php echo esc_html( $discussion['excerpt'] ); ?></p>
+                        <footer class="gaenity-support-hub__discussion-footer">
+                            <span class="gaenity-support-hub__avatar" aria-hidden="true">👤</span>
+                            <span><?php echo esc_html( $discussion['author'] ); ?></span>
+                            <span class="gaenity-support-hub__meta-divider" aria-hidden="true">·</span>
+                            <span><?php echo esc_html( $discussion['responses'] ); ?> <?php esc_html_e( 'responses', 'gaenity-community' ); ?></span>
+                        </footer>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render register block.
+     *
+     * @return string
+     */
+    public function render_register_block() {
+        $this->enqueue_assets();
+        $demo_roles = $this->get_demo_roles();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-register">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Create Your Account', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'Tell us a little about yourself to personalise your community journey.', 'gaenity-community' ); ?></p>
+            </header>
+            <form class="gaenity-support-hub__form" method="post" data-success="<?php esc_attr_e( 'Registration submitted! Check your email to confirm your account.', 'gaenity-community' ); ?>">
+                <div class="gaenity-support-hub__grid">
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Full Name', 'gaenity-community' ); ?></span>
+                        <input type="text" name="full_name" required />
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Display Name', 'gaenity-community' ); ?></span>
+                        <input type="text" name="display_name" required />
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Email', 'gaenity-community' ); ?></span>
+                        <input type="email" name="email" required />
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Role / Title', 'gaenity-community' ); ?></span>
+                        <select name="role" required>
+                            <?php foreach ( $demo_roles as $role ) : ?>
+                                <option value="<?php echo esc_attr( $role ); ?>"><?php echo esc_html( $role ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Region', 'gaenity-community' ); ?></span>
+                        <select name="region" required>
+                            <?php foreach ( $this->get_demo_regions() as $region ) : ?>
+                                <option value="<?php echo esc_attr( $region ); ?>"><?php echo esc_html( $region ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Country', 'gaenity-community' ); ?></span>
+                        <input type="text" name="country" required />
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Industry', 'gaenity-community' ); ?></span>
+                        <select name="industry" required>
+                            <?php foreach ( $this->get_demo_industries() as $industry ) : ?>
+                                <option value="<?php echo esc_attr( $industry ); ?>"><?php echo esc_html( $industry ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Primary Challenge', 'gaenity-community' ); ?></span>
+                        <select name="challenge" required>
+                            <?php foreach ( $this->get_demo_challenges() as $challenge ) : ?>
+                                <option value="<?php echo esc_attr( $challenge ); ?>"><?php echo esc_html( $challenge ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </label>
+                    <label class="gaenity-support-hub__field gaenity-support-hub__field--full">
+                        <span><?php esc_html_e( 'Goals for Joining', 'gaenity-community' ); ?></span>
+                        <textarea name="goals" rows="3" required></textarea>
+                    </label>
+                    <label class="gaenity-support-hub__choice">
+                        <input type="checkbox" name="guidelines" required />
+                        <span><?php esc_html_e( 'I agree to the community guidelines', 'gaenity-community' ); ?></span>
+                    </label>
+                    <label class="gaenity-support-hub__choice">
+                        <input type="checkbox" name="updates" />
+                        <span><?php esc_html_e( 'I agree to receive updates from Gaenity', 'gaenity-community' ); ?></span>
+                    </label>
+                </div>
+                <button class="gaenity-support-hub__btn" type="submit"><?php esc_html_e( 'Submit Registration', 'gaenity-community' ); ?></button>
+                <p class="gaenity-support-hub__form-notice" aria-live="polite"></p>
+            </form>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render login block.
+     *
+     * @return string
+     */
+    public function render_login_block() {
+        $this->enqueue_assets();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-login">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Member Login', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'Access exclusive discussions, polls, and expert insights tailored to your profile.', 'gaenity-community' ); ?></p>
+            </header>
+            <form class="gaenity-support-hub__form" method="post" data-success="<?php esc_attr_e( 'Welcome back! You are now signed in.', 'gaenity-community' ); ?>">
+                <div class="gaenity-support-hub__grid">
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Email', 'gaenity-community' ); ?></span>
+                        <input type="email" name="login_email" required />
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Password', 'gaenity-community' ); ?></span>
+                        <input type="password" name="login_password" required />
+                    </label>
+                </div>
+                <div class="gaenity-support-hub__form-footer">
+                    <label class="gaenity-support-hub__choice">
+                        <input type="checkbox" name="remember" />
+                        <span><?php esc_html_e( 'Keep me signed in', 'gaenity-community' ); ?></span>
+                    </label>
+                    <a class="gaenity-support-hub__link" href="#gaenity-register"><?php esc_html_e( 'Need an account?', 'gaenity-community' ); ?></a>
+                </div>
+                <button class="gaenity-support-hub__btn" type="submit"><?php esc_html_e( 'Sign In', 'gaenity-community' ); ?></button>
+                <p class="gaenity-support-hub__form-notice" aria-live="polite"></p>
+            </form>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render chat block.
+     *
+     * @return string
+     */
+    public function render_chat_block() {
+        $this->enqueue_assets();
+
+        $messages = $this->get_demo_chat_messages();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-chat">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Community Chat', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'Drop a quick question or respond to peers in real time. Anonymous mode available for sensitive topics.', 'gaenity-community' ); ?></p>
+            </header>
+            <div class="gaenity-support-hub__chat">
+                <div class="gaenity-support-hub__chat-feed" role="log" aria-live="polite">
+                    <?php foreach ( $messages as $message ) : ?>
+                        <div class="gaenity-support-hub__chat-message">
+                            <div class="gaenity-support-hub__chat-meta">
+                                <span class="gaenity-support-hub__badge"><?php echo esc_html( $message['author'] ); ?></span>
+                                <span><?php echo esc_html( $message['timestamp'] ); ?></span>
+                            </div>
+                            <p><?php echo esc_html( $message['content'] ); ?></p>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+                <form class="gaenity-support-hub__form gaenity-support-hub__chat-form" method="post" data-success="<?php esc_attr_e( 'Message posted!', 'gaenity-community' ); ?>">
+                    <label class="gaenity-support-hub__choice">
+                        <input type="checkbox" name="anonymous" />
+                        <span><?php esc_html_e( 'Post anonymously', 'gaenity-community' ); ?></span>
+                    </label>
+                    <label class="gaenity-support-hub__field gaenity-support-hub__field--full">
+                        <span class="screen-reader-text"><?php esc_html_e( 'Your message', 'gaenity-community' ); ?></span>
+                        <textarea name="message" rows="2" placeholder="<?php esc_attr_e( 'Share your update, win, or question…', 'gaenity-community' ); ?>" required></textarea>
+                    </label>
+                    <button class="gaenity-support-hub__btn" type="submit"><?php esc_html_e( 'Send', 'gaenity-community' ); ?></button>
+                    <p class="gaenity-support-hub__form-notice" aria-live="polite"></p>
+                </form>
+            </div>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render resources section.
+     *
+     * @return string
+     */
+    protected function render_resources_section() {
+        $resources = $this->get_demo_resources();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-resources">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Resources', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'Guides, templates, and case studies to support smarter business decisions.', 'gaenity-community' ); ?></p>
+            </header>
+            <div class="gaenity-support-hub__resource-grid">
+                <?php foreach ( $resources as $resource ) : ?>
+                    <article class="gaenity-support-hub__resource-card">
+                        <div class="gaenity-support-hub__resource-illustration" aria-hidden="true">
+                            <span><?php echo esc_html( $resource['emoji'] ); ?></span>
+                        </div>
+                        <div class="gaenity-support-hub__resource-content">
+                            <h3><?php echo esc_html( $resource['title'] ); ?></h3>
+                            <p><?php echo esc_html( $resource['description'] ); ?></p>
+                            <button class="gaenity-support-hub__btn gaenity-support-hub__btn--ghost" type="button">
+                                <?php esc_html_e( 'Download sample', 'gaenity-community' ); ?>
+                            </button>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render polls section.
+     *
+     * @return string
+     */
+    protected function render_polls_section() {
+        $polls = $this->get_demo_polls();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-polls">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Pulse Polls', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'Collect quick, statistically useful signals from members to understand needs across region and industry.', 'gaenity-community' ); ?></p>
+            </header>
+            <div class="gaenity-support-hub__poll-grid">
+                <?php foreach ( $polls as $poll ) : ?>
+                    <article class="gaenity-support-hub__poll-card">
+                        <header>
+                            <span class="gaenity-support-hub__badge gaenity-support-hub__badge--accent"><?php echo esc_html( $poll['category'] ); ?></span>
+                            <h3><?php echo esc_html( $poll['question'] ); ?></h3>
+                        </header>
+                        <ul class="gaenity-support-hub__poll-options">
+                            <?php foreach ( $poll['options'] as $option ) : ?>
+                                <li>
+                                    <span><?php echo esc_html( $option['label'] ); ?></span>
+                                    <span><?php echo esc_html( $option['value'] ); ?>%</span>
+                                    <span class="gaenity-support-hub__progress" style="--gaenity-progress: <?php echo esc_attr( $option['value'] ); ?>%;"></span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                        <footer>
+                            <button class="gaenity-support-hub__btn gaenity-support-hub__btn--subtle" type="button"><?php esc_html_e( 'Cast your vote', 'gaenity-community' ); ?></button>
+                        </footer>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render featured experts.
+     *
+     * @return string
+     */
+    protected function render_experts_section() {
+        $experts = $this->get_demo_experts();
+
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-experts">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Featured Experts', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'Connect with vetted advisors for tailored, paid support via email or virtual sessions.', 'gaenity-community' ); ?></p>
+            </header>
+            <div class="gaenity-support-hub__expert-grid">
+                <?php foreach ( $experts as $expert ) : ?>
+                    <article class="gaenity-support-hub__expert-card">
+                        <div class="gaenity-support-hub__expert-avatar" aria-hidden="true">👩‍💼</div>
+                        <h3><?php echo esc_html( $expert['name'] ); ?></h3>
+                        <p class="gaenity-support-hub__expert-role"><?php echo esc_html( $expert['role'] ); ?></p>
+                        <p><?php echo esc_html( $expert['bio'] ); ?></p>
+                        <div class="gaenity-support-hub__expert-tags">
+                            <?php foreach ( $expert['focus'] as $focus ) : ?>
+                                <span class="gaenity-support-hub__badge gaenity-support-hub__badge--ghost"><?php echo esc_html( $focus ); ?></span>
+                            <?php endforeach; ?>
+                        </div>
+                        <div class="gaenity-support-hub__expert-actions">
+                            <button class="gaenity-support-hub__btn gaenity-support-hub__btn--ghost" type="button"><?php esc_html_e( 'Email consultation', 'gaenity-community' ); ?></button>
+                            <button class="gaenity-support-hub__btn" type="button"><?php esc_html_e( '30 min virtual meeting', 'gaenity-community' ); ?></button>
+                        </div>
+                    </article>
+                <?php endforeach; ?>
+            </div>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render contact section.
+     *
+     * @return string
+     */
+    protected function render_contact_section() {
+        ob_start();
+        ?>
+        <section class="gaenity-support-hub__section" id="gaenity-contact">
+            <header class="gaenity-support-hub__section-header">
+                <h2><?php esc_html_e( 'Need tailored support?', 'gaenity-community' ); ?></h2>
+                <p><?php esc_html_e( 'We welcome questions, ideas, and collaboration. Send us a message and our team will respond shortly.', 'gaenity-community' ); ?></p>
+            </header>
+            <form class="gaenity-support-hub__form" method="post" data-success="<?php esc_attr_e( 'Thanks for reaching out. We will reply soon.', 'gaenity-community' ); ?>">
+                <div class="gaenity-support-hub__grid">
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Name', 'gaenity-community' ); ?></span>
+                        <input type="text" name="contact_name" required />
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Email', 'gaenity-community' ); ?></span>
+                        <input type="email" name="contact_email" required />
+                    </label>
+                    <label class="gaenity-support-hub__field">
+                        <span><?php esc_html_e( 'Subject', 'gaenity-community' ); ?></span>
+                        <input type="text" name="contact_subject" required />
+                    </label>
+                    <label class="gaenity-support-hub__field gaenity-support-hub__field--full">
+                        <span><?php esc_html_e( 'Message', 'gaenity-community' ); ?></span>
+                        <textarea name="contact_message" rows="4" required></textarea>
+                    </label>
+                    <label class="gaenity-support-hub__choice gaenity-support-hub__field--full">
+                        <input type="checkbox" name="contact_updates" />
+                        <span><?php esc_html_e( 'I agree to receive updates from Gaenity.', 'gaenity-community' ); ?></span>
+                    </label>
+                </div>
+                <button class="gaenity-support-hub__btn" type="submit"><?php esc_html_e( 'Send message', 'gaenity-community' ); ?></button>
+                <p class="gaenity-support-hub__form-notice" aria-live="polite"></p>
+            </form>
+            <div class="gaenity-support-hub__social">
+                <span><?php esc_html_e( 'Follow us', 'gaenity-community' ); ?>:</span>
+                <a href="https://instagram.com" target="_blank" rel="noopener">Instagram</a>
+                <a href="https://facebook.com" target="_blank" rel="noopener">Facebook</a>
+                <a href="https://linkedin.com" target="_blank" rel="noopener">LinkedIn</a>
+            </div>
+        </section>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Render tab panel markup.
+     *
+     * @param string $id    Tab ID.
+     * @param array  $items Items to display.
+     *
+     * @return string
+     */
+    protected function render_tab_panel( $id, $items ) {
+        ob_start();
+        ?>
+        <div class="gaenity-support-hub__tab-panel" id="gaenity-tab-<?php echo esc_attr( $id ); ?>" role="tabpanel">
+            <ul class="gaenity-support-hub__tag-list">
+                <?php foreach ( $items as $item ) : ?>
+                    <li><span class="gaenity-support-hub__badge gaenity-support-hub__badge--ghost"><?php echo esc_html( $item ); ?></span></li>
+                <?php endforeach; ?>
+            </ul>
+        </div>
+        <?php
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Demo regions.
+     *
+     * @return array
+     */
+    protected function get_demo_regions() {
+        return array(
+            __( 'Africa', 'gaenity-community' ),
+            __( 'North America', 'gaenity-community' ),
+            __( 'Europe', 'gaenity-community' ),
+            __( 'Middle East', 'gaenity-community' ),
+            __( 'Asia Pacific', 'gaenity-community' ),
+            __( 'Latin America', 'gaenity-community' ),
+        );
+    }
+
+    /**
+     * Demo industries.
+     *
+     * @return array
+     */
+    protected function get_demo_industries() {
+        return array(
+            __( 'Retail & e-commerce', 'gaenity-community' ),
+            __( 'Manufacturing', 'gaenity-community' ),
+            __( 'Services', 'gaenity-community' ),
+            __( 'Health & wellness', 'gaenity-community' ),
+            __( 'Food & hospitality', 'gaenity-community' ),
+            __( 'Technology & startups', 'gaenity-community' ),
+            __( 'Agriculture', 'gaenity-community' ),
+            __( 'Finance & financial services', 'gaenity-community' ),
+        );
+    }
+
+    /**
+     * Demo challenges.
+     *
+     * @return array
+     */
+    protected function get_demo_challenges() {
+        return array(
+            __( 'Cash flow', 'gaenity-community' ),
+            __( 'Supplier / customer risk', 'gaenity-community' ),
+            __( 'Compliance', 'gaenity-community' ),
+            __( 'Operations', 'gaenity-community' ),
+            __( 'People', 'gaenity-community' ),
+            __( 'Sales & marketing', 'gaenity-community' ),
+            __( 'Technology & data', 'gaenity-community' ),
+            __( 'Financial controls', 'gaenity-community' ),
+            __( 'Credit', 'gaenity-community' ),
+            __( 'Fraud', 'gaenity-community' ),
+        );
+    }
+
+    /**
+     * Demo roles.
+     *
+     * @return array
+     */
+    protected function get_demo_roles() {
+        return array(
+            __( 'Business Owner', 'gaenity-community' ),
+            __( 'Employed Professional', 'gaenity-community' ),
+            __( 'Forum Expert', 'gaenity-community' ),
+        );
+    }
+
+    /**
+     * Demo discussions.
+     *
+     * @return array
+     */
+    protected function get_demo_discussions() {
+        return array(
+            array(
+                'title'     => __( 'Preparing for seasonal cash flow swings', 'gaenity-community' ),
+                'excerpt'   => __( 'Members share tactics for forecasting and balancing working capital ahead of peak months.', 'gaenity-community' ),
+                'topic'     => __( 'Cash flow', 'gaenity-community' ),
+                'region'    => __( 'North America', 'gaenity-community' ),
+                'author'    => 'Lina A.',
+                'responses' => 18,
+            ),
+            array(
+                'title'     => __( 'Supplier diversification checklist', 'gaenity-community' ),
+                'excerpt'   => __( 'How three founders reduced dependency on a single supplier within six weeks.', 'gaenity-community' ),
+                'topic'     => __( 'Supplier risk', 'gaenity-community' ),
+                'region'    => __( 'Europe', 'gaenity-community' ),
+                'author'    => 'Marcus K.',
+                'responses' => 12,
+            ),
+            array(
+                'title'     => __( 'Hiring fractional CFO support', 'gaenity-community' ),
+                'excerpt'   => __( 'Discussing when to bring in part-time finance experts and what to expect in costs.', 'gaenity-community' ),
+                'topic'     => __( 'Finance enablement', 'gaenity-community' ),
+                'region'    => __( 'Africa', 'gaenity-community' ),
+                'author'    => 'Ayodele S.',
+                'responses' => 21,
+            ),
+            array(
+                'title'     => __( 'Customer onboarding automation stack', 'gaenity-community' ),
+                'excerpt'   => __( 'A breakdown of low-code tools to speed up onboarding for service businesses.', 'gaenity-community' ),
+                'topic'     => __( 'Operations', 'gaenity-community' ),
+                'region'    => __( 'Asia Pacific', 'gaenity-community' ),
+                'author'    => 'Jia L.',
+                'responses' => 9,
+            ),
+            array(
+                'title'     => __( 'Keeping remote teams engaged', 'gaenity-community' ),
+                'excerpt'   => __( 'Weekly rituals that boost trust and collaboration across time zones.', 'gaenity-community' ),
+                'topic'     => __( 'People', 'gaenity-community' ),
+                'region'    => __( 'Latin America', 'gaenity-community' ),
+                'author'    => 'Gabriela P.',
+                'responses' => 27,
+            ),
+        );
+    }
+
+    /**
+     * Demo resources.
+     *
+     * @return array
+     */
+    protected function get_demo_resources() {
+        return array(
+            array(
+                'emoji'       => '📊',
+                'title'       => __( 'Cash flow tracker template', 'gaenity-community' ),
+                'description' => __( 'Plan inflows, outflows, and runway with a 12-month rolling forecast spreadsheet.', 'gaenity-community' ),
+            ),
+            array(
+                'emoji'       => '✅',
+                'title'       => __( 'Supplier onboarding checklist', 'gaenity-community' ),
+                'description' => __( 'Standardise due diligence, contract essentials, and contingency plans.', 'gaenity-community' ),
+            ),
+            array(
+                'emoji'       => '🛡️',
+                'title'       => __( 'Risk register template', 'gaenity-community' ),
+                'description' => __( 'Surface emerging threats across finance, operations, and compliance with ease.', 'gaenity-community' ),
+            ),
+            array(
+                'emoji'       => '📈',
+                'title'       => __( 'Growth metrics dashboard', 'gaenity-community' ),
+                'description' => __( 'Monitor KPIs across marketing, retention, and cash conversion in one view.', 'gaenity-community' ),
+            ),
+            array(
+                'emoji'       => '🤝',
+                'title'       => __( 'Partnership proposal kit', 'gaenity-community' ),
+                'description' => __( 'Structure outreach, value articulation, and success metrics for partnerships.', 'gaenity-community' ),
+            ),
+        );
+    }
+
+    /**
+     * Demo polls.
+     *
+     * @return array
+     */
+    protected function get_demo_polls() {
+        return array(
+            array(
+                'category' => __( 'Risk Management', 'gaenity-community' ),
+                'question' => __( 'Which risk area needs the most support this quarter?', 'gaenity-community' ),
+                'options'  => array(
+                    array(
+                        'label' => __( 'Cash flow resilience', 'gaenity-community' ),
+                        'value' => 42,
+                    ),
+                    array(
+                        'label' => __( 'Supplier reliability', 'gaenity-community' ),
+                        'value' => 28,
+                    ),
+                    array(
+                        'label' => __( 'Compliance readiness', 'gaenity-community' ),
+                        'value' => 30,
+                    ),
+                ),
+            ),
+            array(
+                'category' => __( 'Finance Enablement', 'gaenity-community' ),
+                'question' => __( 'How confident are you in your monthly financial reporting?', 'gaenity-community' ),
+                'options'  => array(
+                    array(
+                        'label' => __( 'Very confident', 'gaenity-community' ),
+                        'value' => 35,
+                    ),
+                    array(
+                        'label' => __( 'Somewhat confident', 'gaenity-community' ),
+                        'value' => 44,
+                    ),
+                    array(
+                        'label' => __( 'Need major improvements', 'gaenity-community' ),
+                        'value' => 21,
+                    ),
+                ),
+            ),
+            array(
+                'category' => __( 'Operations', 'gaenity-community' ),
+                'question' => __( 'Where is automation bringing the most value today?', 'gaenity-community' ),
+                'options'  => array(
+                    array(
+                        'label' => __( 'Customer onboarding', 'gaenity-community' ),
+                        'value' => 39,
+                    ),
+                    array(
+                        'label' => __( 'Inventory & fulfilment', 'gaenity-community' ),
+                        'value' => 33,
+                    ),
+                    array(
+                        'label' => __( 'Reporting & analytics', 'gaenity-community' ),
+                        'value' => 28,
+                    ),
+                ),
+            ),
+        );
+    }
+
+    /**
+     * Demo experts.
+     *
+     * @return array
+     */
+    protected function get_demo_experts() {
+        return array(
+            array(
+                'name'  => 'Marissa Okon',
+                'role'  => __( 'Risk Strategist · Lagos, NG', 'gaenity-community' ),
+                'bio'   => __( 'Helps retail and manufacturing founders build robust contingency plans and audit frameworks.', 'gaenity-community' ),
+                'focus' => array( __( 'Risk Management', 'gaenity-community' ), __( 'Compliance', 'gaenity-community' ) ),
+            ),
+            array(
+                'name'  => 'Caleb Montgomery',
+                'role'  => __( 'Fractional CFO · Austin, US', 'gaenity-community' ),
+                'bio'   => __( 'Works with growing startups to design forecasting cadences and investor-ready dashboards.', 'gaenity-community' ),
+                'focus' => array( __( 'Finance Enablement', 'gaenity-community' ), __( 'Investment Readiness', 'gaenity-community' ) ),
+            ),
+            array(
+                'name'  => 'Samira El-Hassan',
+                'role'  => __( 'Operations Architect · Dubai, UAE', 'gaenity-community' ),
+                'bio'   => __( 'Supports service teams with workflow automation and process documentation.', 'gaenity-community' ),
+                'focus' => array( __( 'Operations', 'gaenity-community' ), __( 'Automation', 'gaenity-community' ) ),
+            ),
+            array(
+                'name'  => 'Diego Fernández',
+                'role'  => __( 'Customer Success Lead · Bogotá, CO', 'gaenity-community' ),
+                'bio'   => __( 'Specialises in customer retention, lifecycle messaging, and feedback programmes.', 'gaenity-community' ),
+                'focus' => array( __( 'Customer Success', 'gaenity-community' ), __( 'Service Design', 'gaenity-community' ) ),
+            ),
+            array(
+                'name'  => 'Priya Mehta',
+                'role'  => __( 'Data & Insights Partner · Mumbai, IN', 'gaenity-community' ),
+                'bio'   => __( 'Transforms messy data into actionable dashboards and predictive insights.', 'gaenity-community' ),
+                'focus' => array( __( 'Analytics', 'gaenity-community' ), __( 'Technology & Data', 'gaenity-community' ) ),
+            ),
+        );
+    }
+
+    /**
+     * Demo chat messages.
+     *
+     * @return array
+     */
+    protected function get_demo_chat_messages() {
+        return array(
+            array(
+                'author'    => __( 'Anonymous founder', 'gaenity-community' ),
+                'timestamp' => __( '2 minutes ago', 'gaenity-community' ),
+                'content'   => __( 'Anyone implemented supplier scorecards for local producers? Looking for best practices.', 'gaenity-community' ),
+            ),
+            array(
+                'author'    => 'Lina A.',
+                'timestamp' => __( '10 minutes ago', 'gaenity-community' ),
+                'content'   => __( 'We just published a cash flow automation guide—link in resources!', 'gaenity-community' ),
+            ),
+            array(
+                'author'    => 'Marissa Okon',
+                'timestamp' => __( '25 minutes ago', 'gaenity-community' ),
+                'content'   => __( 'Happy to review risk registers during office hours tomorrow. Drop your doc in the chat.', 'gaenity-community' ),
+            ),
+            array(
+                'author'    => 'Diego Fernández',
+                'timestamp' => __( '1 hour ago', 'gaenity-community' ),
+                'content'   => __( 'Shared our onboarding automation SOP under operations discussions.', 'gaenity-community' ),
+            ),
+            array(
+                'author'    => 'Community Bot',
+                'timestamp' => __( '3 hours ago', 'gaenity-community' ),
+                'content'   => __( 'Benchmark poll: What’s your top priority this month? Vote now in the polls section.', 'gaenity-community' ),
+            ),
+        );
+    }
+}

--- a/gaenity-support-styler/README.md
+++ b/gaenity-support-styler/README.md
@@ -1,0 +1,22 @@
+# Gaenity Support Styler
+
+A helper plugin authored by **Skillscore IT Solutions and Training** that forces the Gaenity Support Hub front-end assets to load everywhere. Activate this plugin alongside the main Gaenity Support Hub experience to guarantee that Elementor previews and regular pages inherit the polished styling and JavaScript interactions.
+
+## Usage
+
+1. Upload both the `gaenity-community` plugin and this `gaenity-support-styler` helper plugin to `wp-content/plugins/`.
+2. Activate **Gaenity Support Hub** first, then activate **Gaenity Support Styler**.
+3. Add the `[gaenity_support_hub]` shortcode or the individual shortcodes (`[gaenity_community]`, `[gaenity_register]`, `[gaenity_login]`, `[gaenity_chat]`) to any page.
+4. The styler plugin will automatically enqueue the required CSS and JavaScript assets on every page load and inside Elementor.
+
+## Fallback assets
+
+If the primary plugin's copies of `assets/css/support-hub.css` or `assets/js/support-hub.js` are missing, the helper ships with identical fallbacks so the interface remains consistent.
+
+## Development
+
+- Version: 1.0.0
+- Requires WordPress 5.8+
+- Requires PHP 7.4+
+
+Feel free to customise the bundled styles if you would like to adjust the design globally.

--- a/gaenity-support-styler/assets/css/support-hub.css
+++ b/gaenity-support-styler/assets/css/support-hub.css
@@ -1,0 +1,510 @@
+:root {
+    --gaenity-color-primary: #1e4dd8;
+    --gaenity-color-primary-soft: rgba(30, 77, 216, 0.12);
+    --gaenity-color-surface: #ffffff;
+    --gaenity-color-muted: #6a6f85;
+    --gaenity-color-border: rgba(15, 23, 42, 0.12);
+    --gaenity-radius-large: 24px;
+    --gaenity-radius-medium: 16px;
+    --gaenity-radius-small: 10px;
+    --gaenity-shadow-soft: 0 20px 45px -25px rgba(15, 23, 42, 0.45);
+    --gaenity-gap: clamp(1.5rem, 2vw, 2.25rem);
+}
+
+.gaenity-support-hub,
+.gaenity-support-hub * {
+    box-sizing: border-box;
+}
+
+.gaenity-support-hub {
+    font-family: inherit;
+}
+
+.gaenity-support-hub a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.gaenity-support-hub__hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: var(--gaenity-gap);
+    padding: clamp(3rem, 6vw, 5rem);
+    background: linear-gradient(135deg, rgba(30, 77, 216, 0.08), rgba(30, 77, 216, 0.22));
+    border-radius: var(--gaenity-radius-large);
+    margin-bottom: clamp(3rem, 6vw, 4rem);
+}
+
+.gaenity-support-hub__hero-content {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.gaenity-support-hub__eyebrow {
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(30, 31, 73, 0.7);
+}
+
+.gaenity-support-hub__headline {
+    margin: 0;
+    font-size: clamp(2.5rem, 4vw, 3.5rem);
+}
+
+.gaenity-support-hub__intro {
+    margin: 0;
+    color: var(--gaenity-color-muted);
+    font-size: 1.1rem;
+    max-width: 42ch;
+}
+
+.gaenity-support-hub__hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.gaenity-support-hub__hero-panel {
+    background: var(--gaenity-color-surface);
+    border-radius: var(--gaenity-radius-medium);
+    padding: 2rem;
+    box-shadow: var(--gaenity-shadow-soft);
+    align-self: stretch;
+}
+
+.gaenity-support-hub__hero-highlights {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.gaenity-support-hub__highlight-label {
+    display: block;
+    color: var(--gaenity-color-muted);
+    font-size: 0.9rem;
+}
+
+.gaenity-support-hub__highlight-value {
+    font-size: 1.75rem;
+    font-weight: 700;
+}
+
+.gaenity-support-hub__section {
+    margin-bottom: clamp(3rem, 6vw, 4.5rem);
+}
+
+.gaenity-support-hub__section-header {
+    display: grid;
+    gap: 0.75rem;
+    margin-bottom: clamp(1.5rem, 3vw, 2.5rem);
+    max-width: 720px;
+}
+
+.gaenity-support-hub__section-header h2 {
+    margin: 0;
+    font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.gaenity-support-hub__section-header p {
+    margin: 0;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__notice {
+    margin-bottom: 1.5rem;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    background: rgba(30, 77, 216, 0.12);
+    color: #1b2556;
+    font-weight: 600;
+}
+
+.gaenity-support-hub__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.75rem;
+    background: var(--gaenity-color-primary);
+    color: #fff;
+    border-radius: 999px;
+    border: none;
+    font-weight: 600;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.gaenity-support-hub__btn:hover,
+.gaenity-support-hub__btn:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 18px -12px rgba(30, 77, 216, 0.65);
+}
+
+.gaenity-support-hub__btn--ghost {
+    background: rgba(30, 77, 216, 0.12);
+    color: #1e2a5a;
+}
+
+.gaenity-support-hub__btn--subtle {
+    background: transparent;
+    color: var(--gaenity-color-primary);
+    border: 1px solid rgba(30, 77, 216, 0.2);
+}
+
+.gaenity-support-hub__resource-grid,
+.gaenity-support-hub__discussion-grid,
+.gaenity-support-hub__poll-grid,
+.gaenity-support-hub__expert-grid {
+    display: grid;
+    gap: var(--gaenity-gap);
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.gaenity-support-hub__resource-card,
+.gaenity-support-hub__discussion-card,
+.gaenity-support-hub__poll-card,
+.gaenity-support-hub__expert-card {
+    background: var(--gaenity-color-surface);
+    border-radius: var(--gaenity-radius-medium);
+    padding: clamp(1.5rem, 3vw, 2rem);
+    border: 1px solid var(--gaenity-color-border);
+    box-shadow: 0 12px 35px -30px rgba(15, 23, 42, 0.7);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 100%;
+}
+
+.gaenity-support-hub__resource-illustration {
+    width: 60px;
+    height: 60px;
+    border-radius: 16px;
+    display: grid;
+    place-items: center;
+    font-size: 1.75rem;
+    background: var(--gaenity-color-primary-soft);
+}
+
+.gaenity-support-hub__resource-card h3,
+.gaenity-support-hub__discussion-card h3,
+.gaenity-support-hub__poll-card h3,
+.gaenity-support-hub__expert-card h3 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.gaenity-support-hub__resource-card p,
+.gaenity-support-hub__discussion-card p,
+.gaenity-support-hub__poll-card p,
+.gaenity-support-hub__expert-card p {
+    margin: 0;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(30, 77, 216, 0.15);
+    color: #1d2d50;
+    font-size: 0.85rem;
+    font-weight: 600;
+}
+
+.gaenity-support-hub__badge--ghost {
+    background: rgba(15, 23, 42, 0.06);
+    color: #364152;
+}
+
+.gaenity-support-hub__badge--accent {
+    background: rgba(255, 174, 0, 0.16);
+    color: #8a5800;
+}
+
+.gaenity-support-hub__discussion-meta {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.gaenity-support-hub__discussion-footer {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    color: var(--gaenity-color-muted);
+    font-size: 0.9rem;
+}
+
+.gaenity-support-hub__meta-divider {
+    opacity: 0.6;
+}
+
+.gaenity-support-hub__avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 999px;
+    background: rgba(30, 77, 216, 0.18);
+    display: grid;
+    place-items: center;
+    font-size: 0.9rem;
+}
+
+.gaenity-support-hub__tabs {
+    display: inline-flex;
+    border-radius: 999px;
+    padding: 0.4rem;
+    background: rgba(15, 23, 42, 0.05);
+    margin-bottom: 1.5rem;
+}
+
+.gaenity-support-hub__tab {
+    border: none;
+    background: transparent;
+    padding: 0.6rem 1.2rem;
+    border-radius: 999px;
+    font-weight: 600;
+    color: var(--gaenity-color-muted);
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.gaenity-support-hub__tab.is-active {
+    background: #fff;
+    color: #172554;
+    box-shadow: 0 10px 20px -15px rgba(15, 23, 42, 0.55);
+}
+
+.gaenity-support-hub__tab-panels {
+    position: relative;
+}
+
+.gaenity-support-hub__tab-panel {
+    display: none;
+    padding: 0.5rem 0;
+}
+
+.gaenity-support-hub__tab-panel.is-active {
+    display: block;
+}
+
+.gaenity-support-hub__tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.gaenity-support-hub__form {
+    background: var(--gaenity-color-surface);
+    border-radius: var(--gaenity-radius-medium);
+    padding: clamp(1.75rem, 3vw, 2.5rem);
+    border: 1px solid var(--gaenity-color-border);
+    box-shadow: 0 15px 35px -32px rgba(15, 23, 42, 0.55);
+    display: grid;
+    gap: 1.5rem;
+}
+
+.gaenity-support-hub__grid {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.gaenity-support-hub__field {
+    display: grid;
+    gap: 0.4rem;
+}
+
+.gaenity-support-hub__field--full {
+    grid-column: 1 / -1;
+}
+
+.gaenity-support-hub__field span,
+.gaenity-support-hub__choice span {
+    font-weight: 600;
+    color: #1a1f2d;
+}
+
+.gaenity-support-hub__field input,
+.gaenity-support-hub__field select,
+.gaenity-support-hub__field textarea {
+    width: 100%;
+    padding: 0.75rem 1rem;
+    border-radius: 12px;
+    border: 1px solid rgba(15, 23, 42, 0.18);
+    background: rgba(248, 250, 255, 0.75);
+    font: inherit;
+    color: inherit;
+}
+
+.gaenity-support-hub__field textarea {
+    resize: vertical;
+}
+
+.gaenity-support-hub__choice {
+    display: flex;
+    align-items: center;
+    gap: 0.65rem;
+    font-size: 0.95rem;
+}
+
+.gaenity-support-hub__choice input {
+    width: 1.1rem;
+    height: 1.1rem;
+}
+
+.gaenity-support-hub__form-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.gaenity-support-hub__link {
+    color: var(--gaenity-color-primary);
+    font-weight: 600;
+}
+
+.gaenity-support-hub__form-notice {
+    margin: 0;
+    color: var(--gaenity-color-primary);
+    font-weight: 600;
+    display: none;
+}
+
+.gaenity-support-hub__form-notice.is-visible {
+    display: block;
+}
+
+.gaenity-support-hub__chat {
+    display: grid;
+    gap: var(--gaenity-gap);
+}
+
+.gaenity-support-hub__chat-feed {
+    max-height: 320px;
+    overflow-y: auto;
+    display: grid;
+    gap: 1rem;
+    padding-right: 0.5rem;
+}
+
+.gaenity-support-hub__chat-message {
+    padding: 1rem 1.25rem;
+    border-radius: var(--gaenity-radius-small);
+    background: rgba(248, 250, 255, 0.85);
+    border: 1px solid rgba(15, 23, 42, 0.08);
+    display: grid;
+    gap: 0.35rem;
+}
+
+.gaenity-support-hub__chat-meta {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__poll-options {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.gaenity-support-hub__poll-options li {
+    display: grid;
+    gap: 0.3rem;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__progress {
+    display: block;
+    height: 6px;
+    border-radius: 999px;
+    background: rgba(30, 77, 216, 0.18);
+    position: relative;
+}
+
+.gaenity-support-hub__progress::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: var(--gaenity-color-primary);
+    transform: scaleX(calc(var(--gaenity-progress) / 100));
+    transform-origin: left;
+}
+
+.gaenity-support-hub__expert-avatar {
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: rgba(30, 77, 216, 0.15);
+    font-size: 1.5rem;
+    align-self: flex-start;
+}
+
+.gaenity-support-hub__expert-role {
+    font-weight: 600;
+    color: #1a1f2d;
+}
+
+.gaenity-support-hub__expert-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.gaenity-support-hub__expert-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: auto;
+}
+
+.gaenity-support-hub__social {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+    color: var(--gaenity-color-muted);
+}
+
+.gaenity-support-hub__social a {
+    color: var(--gaenity-color-primary);
+    font-weight: 600;
+}
+
+@media (max-width: 640px) {
+    .gaenity-support-hub__hero {
+        padding: 2.5rem;
+    }
+
+    .gaenity-support-hub__hero-panel {
+        padding: 1.5rem;
+    }
+
+    .gaenity-support-hub__grid {
+        grid-template-columns: 1fr;
+    }
+
+    .gaenity-support-hub__hero-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}

--- a/gaenity-support-styler/assets/js/support-hub.js
+++ b/gaenity-support-styler/assets/js/support-hub.js
@@ -1,0 +1,73 @@
+(function ($) {
+    'use strict';
+
+    const selectors = {
+        tab: '[data-gaenity-tab]',
+        tabPanel: '.gaenity-support-hub__tab-panel',
+        form: '.gaenity-support-hub__form',
+    };
+
+    function activateTab($button) {
+        const target = $button.data('gaenity-tab');
+
+        $button
+            .addClass('is-active')
+            .attr({
+                'aria-selected': 'true',
+                tabindex: '0',
+            })
+            .siblings()
+            .removeClass('is-active')
+            .attr({
+                'aria-selected': 'false',
+                tabindex: '-1',
+            });
+
+        $button
+            .closest('.gaenity-support-hub__section')
+            .find(selectors.tabPanel)
+            .removeClass('is-active')
+            .attr('hidden', true)
+            .filter('#gaenity-tab-' + target)
+            .addClass('is-active')
+            .removeAttr('hidden');
+    }
+
+    function bindTabs($context) {
+        $context.on('click keydown', selectors.tab, function (event) {
+            if (event.type === 'keydown' && event.key !== 'Enter' && event.key !== ' ') {
+                return;
+            }
+
+            event.preventDefault();
+            activateTab($(this));
+        });
+
+        $context.find(selectors.tab).first().trigger('click');
+    }
+
+    function bindForms($context) {
+        $context.on('submit', selectors.form, function (event) {
+            event.preventDefault();
+            const $form = $(this);
+            const message = $form.data('success') || 'Submission received!';
+            const $notice = $form.find('.gaenity-support-hub__form-notice');
+
+            if ($notice.length) {
+                $notice.text(message).addClass('is-visible');
+            }
+
+            this.reset();
+        });
+    }
+
+    $(function () {
+        const $hub = $('[data-gaenity-component="support-hub"]');
+
+        if ($hub.length) {
+            bindTabs($hub);
+        }
+
+        bindForms($(document));
+    });
+})(jQuery);

--- a/gaenity-support-styler/gaenity-support-styler.php
+++ b/gaenity-support-styler/gaenity-support-styler.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Plugin Name:       Gaenity Support Styler
+ * Description:       Companion plugin that forces the Gaenity Support Hub assets to load so layouts stay styled everywhere, including Elementor preview.
+ * Version:           1.0.0
+ * Requires at least: 5.8
+ * Requires PHP:      7.4
+ * Author:            Skillscore IT Solutions and Training
+ * Author URI:        https://skillscoreitsolutions.com/
+ * Text Domain:       gaenity-support-styler
+ *
+ * @package GaenitySupportStyler
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( 'Gaenity_Support_Styler' ) ) {
+    /**
+     * Forces Gaenity Support Hub styling assets to load globally.
+     */
+    class Gaenity_Support_Styler {
+
+        /**
+         * Plugin version.
+         */
+        const VERSION = '1.0.0';
+
+        /**
+         * Singleton instance.
+         *
+         * @var Gaenity_Support_Styler|null
+         */
+        protected static $instance = null;
+
+        /**
+         * Bootstraps the plugin.
+         *
+         * @return Gaenity_Support_Styler
+         */
+        public static function instance() {
+            if ( null === self::$instance ) {
+                self::$instance = new self();
+                self::$instance->hooks();
+            }
+
+            return self::$instance;
+        }
+
+        /**
+         * Register WordPress hooks.
+         */
+        protected function hooks() {
+            add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ), 5 );
+            add_action( 'elementor/frontend/before_enqueue_styles', array( $this, 'enqueue_assets' ), 5 );
+            add_action( 'elementor/editor/before_enqueue_scripts', array( $this, 'enqueue_assets' ), 5 );
+        }
+
+        /**
+         * Enqueue the Support Hub assets with a fallback copy bundled in this helper plugin.
+         */
+        public function enqueue_assets() {
+            $css_url = $this->resolve_asset_url( 'assets/css/support-hub.css', 'css' );
+            $js_url  = $this->resolve_asset_url( 'assets/js/support-hub.js', 'js' );
+
+            if ( $css_url ) {
+                wp_register_style( 'gaenity-support-styler', $css_url, array(), self::VERSION );
+                wp_enqueue_style( 'gaenity-support-styler' );
+            }
+
+            if ( $js_url ) {
+                wp_register_script( 'gaenity-support-styler', $js_url, array( 'jquery' ), self::VERSION, true );
+                wp_enqueue_script( 'gaenity-support-styler' );
+            }
+        }
+
+        /**
+         * Resolve URL for an asset, preferring the main community plugin copy and falling back to the bundled version.
+         *
+         * @param string $relative_path The asset path relative to the target plugin root.
+         * @param string $type          Asset type for validation (css/js).
+         *
+         * @return string|false
+         */
+        protected function resolve_asset_url( $relative_path, $type ) {
+            $community_path = trailingslashit( WP_PLUGIN_DIR ) . 'gaenity-community/' . $relative_path;
+
+            if ( file_exists( $community_path ) ) {
+                $url = plugins_url( '/gaenity-community/' . $relative_path );
+
+                if ( $url ) {
+                    return $url;
+                }
+            }
+
+            $bundled_path = plugin_dir_path( __FILE__ ) . $relative_path;
+
+            if ( file_exists( $bundled_path ) ) {
+                return plugins_url( $relative_path, __FILE__ );
+            }
+
+            if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                error_log( sprintf( 'Gaenity Support Styler could not locate %s asset: %s', $type, $relative_path ) );
+            }
+
+            return false;
+        }
+    }
+}
+
+Gaenity_Support_Styler::instance();


### PR DESCRIPTION
## Summary
- add the Gaenity Support Styler companion plugin authored by Skillscore IT Solutions and Training
- ensure the helper forces the Support Hub CSS and JavaScript to load globally with Elementor coverage and fallbacks
- document activation steps and fallback behaviour for the styling helper

## Testing
- php -l gaenity-support-styler/gaenity-support-styler.php

------
https://chatgpt.com/codex/tasks/task_e_68d42739d27083339003a352b9536f72