### PR TITLE
Add TekGurus WordPress theme with Bricks support

### DIFF
--- a/tekgurus-theme/assets/images/aws-logo.svg
+++ b/tekgurus-theme/assets/images/aws-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120" role="img" aria-labelledby="title desc">
+  <title id="title">AWS alliance mark</title>
+  <desc id="desc">Simplified AWS inspired wordmark for placeholder use.</desc>
+  <rect width="240" height="120" rx="16" fill="#121212" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', 'Arial', sans-serif" font-size="48" fill="#ffffff">AWS</text>
+  <path d="M50 90 C90 110, 150 110, 190 90" stroke="#e5252a" stroke-width="6" fill="none" stroke-linecap="round" />
+</svg>

--- a/tekgurus-theme/assets/images/azure-logo.svg
+++ b/tekgurus-theme/assets/images/azure-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120" role="img" aria-labelledby="title desc">
+  <title id="title">Azure alliance mark</title>
+  <desc id="desc">Simplified Azure inspired wordmark for placeholder use.</desc>
+  <rect width="240" height="120" rx="16" fill="#0f0f15" />
+  <text x="50%" y="58%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', 'Arial', sans-serif" font-size="40" fill="#ffffff">Azure</text>
+  <path d="M70 86 L120 36 L170 86" stroke="#e5252a" stroke-width="8" fill="none" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/tekgurus-theme/assets/images/gcp-logo.svg
+++ b/tekgurus-theme/assets/images/gcp-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120" role="img" aria-labelledby="title desc">
+  <title id="title">Google Cloud alliance mark</title>
+  <desc id="desc">Simplified GCP inspired wordmark for placeholder use.</desc>
+  <rect width="240" height="120" rx="16" fill="#111117" />
+  <text x="50%" y="54%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', 'Arial', sans-serif" font-size="44" fill="#ffffff">GCP</text>
+  <circle cx="120" cy="90" r="28" fill="none" stroke="#e5252a" stroke-width="6" />
+</svg>

--- a/tekgurus-theme/assets/images/hero1.svg
+++ b/tekgurus-theme/assets/images/hero1.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Abstract cloud technology background</title>
+  <desc id="desc">A vibrant gradient background with connected nodes suggesting cloud technology.</desc>
+  <defs>
+    <linearGradient id="hero1Gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b0b0f" />
+      <stop offset="50%" stop-color="#1a1f3b" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+    <radialGradient id="hero1Glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.25" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1440" height="900" fill="url(#hero1Gradient)" />
+  <circle cx="720" cy="420" r="420" fill="url(#hero1Glow)" />
+  <g stroke="#ffffff" stroke-opacity="0.3" stroke-width="2" fill="none">
+    <path d="M160 260 C400 160, 560 620, 840 520 S1240 280, 1320 620" />
+    <path d="M120 600 C360 760, 640 340, 900 480 S1200 740, 1380 540" />
+  </g>
+  <g fill="#ffffff" fill-opacity="0.65">
+    <circle cx="220" cy="300" r="12" />
+    <circle cx="420" cy="210" r="10" />
+    <circle cx="640" cy="600" r="14" />
+    <circle cx="940" cy="500" r="12" />
+    <circle cx="1200" cy="360" r="10" />
+    <circle cx="1080" cy="640" r="9" />
+  </g>
+</svg>

--- a/tekgurus-theme/assets/images/hero2.svg
+++ b/tekgurus-theme/assets/images/hero2.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Digital mesh background</title>
+  <desc id="desc">Dark background with red accents and circuit-inspired mesh.</desc>
+  <defs>
+    <linearGradient id="hero2Gradient" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#040404" />
+      <stop offset="50%" stop-color="#111723" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+    <linearGradient id="hero2Lines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.12" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="900" fill="url(#hero2Gradient)" />
+  <g stroke="url(#hero2Lines)" stroke-width="1.5" fill="none">
+    <path d="M120 160 L340 320 L540 200 L760 340 L980 220 L1200 360 L1380 240" />
+    <path d="M120 420 L320 540 L520 420 L720 560 L940 440 L1140 560 L1360 440" />
+    <path d="M120 700 L360 820 L560 700 L780 820 L1000 700 L1200 820 L1380 700" />
+  </g>
+  <g fill="#ffffff" fill-opacity="0.55">
+    <circle cx="340" cy="320" r="12" />
+    <circle cx="540" cy="200" r="9" />
+    <circle cx="760" cy="340" r="11" />
+    <circle cx="980" cy="220" r="10" />
+    <circle cx="1140" cy="560" r="9" />
+    <circle cx="360" cy="820" r="10" />
+    <circle cx="780" cy="820" r="12" />
+  </g>
+</svg>

--- a/tekgurus-theme/assets/images/hero3.svg
+++ b/tekgurus-theme/assets/images/hero3.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Modern data visualization background</title>
+  <desc id="desc">Stylized bars and nodes representing analytics over a dark gradient.</desc>
+  <defs>
+    <linearGradient id="hero3Gradient" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#050608" />
+      <stop offset="50%" stop-color="#141b2e" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+    <linearGradient id="hero3Bars" x1="0%" y1="100%" x2="0%" y2="0%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0.35" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="900" fill="url(#hero3Gradient)" />
+  <g fill="url(#hero3Bars)">
+    <rect x="160" y="460" width="80" height="260" rx="12" />
+    <rect x="300" y="380" width="80" height="340" rx="12" />
+    <rect x="440" y="420" width="80" height="300" rx="12" />
+    <rect x="580" y="340" width="80" height="380" rx="12" />
+    <rect x="720" y="400" width="80" height="320" rx="12" />
+    <rect x="860" y="360" width="80" height="360" rx="12" />
+    <rect x="1000" y="420" width="80" height="300" rx="12" />
+    <rect x="1140" y="480" width="80" height="240" rx="12" />
+  </g>
+  <g fill="#ffffff" fill-opacity="0.55">
+    <circle cx="200" cy="440" r="10" />
+    <circle cx="340" cy="360" r="12" />
+    <circle cx="480" cy="400" r="9" />
+    <circle cx="620" cy="320" r="12" />
+    <circle cx="760" cy="380" r="9" />
+    <circle cx="900" cy="340" r="11" />
+    <circle cx="1040" cy="400" r="9" />
+    <circle cx="1180" cy="460" r="10" />
+  </g>
+</svg>

--- a/tekgurus-theme/assets/images/hero4.svg
+++ b/tekgurus-theme/assets/images/hero4.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Futuristic grid background</title>
+  <desc id="desc">Red-tinted grid with waveforms representing innovation.</desc>
+  <defs>
+    <linearGradient id="hero4Gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#18191f" />
+      <stop offset="40%" stop-color="#111112" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+    <linearGradient id="hero4Wave" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0" />
+      <stop offset="50%" stop-color="#ffffff" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="900" fill="url(#hero4Gradient)" />
+  <g stroke="#ffffff" stroke-opacity="0.07" stroke-width="2">
+    <path d="M0 760 H1440" />
+    <path d="M0 680 H1440" />
+    <path d="M0 600 H1440" />
+    <path d="M0 520 H1440" />
+    <path d="M0 440 H1440" />
+    <path d="M0 360 H1440" />
+    <path d="M0 280 H1440" />
+    <path d="M0 200 H1440" />
+  </g>
+  <path d="M0 620 C200 520, 400 700, 600 620 S1000 500, 1200 620 S1400 520, 1440 600" fill="none" stroke="url(#hero4Wave)" stroke-width="6" />
+  <g fill="#ffffff" fill-opacity="0.6">
+    <circle cx="180" cy="620" r="10" />
+    <circle cx="420" cy="700" r="8" />
+    <circle cx="660" cy="610" r="11" />
+    <circle cx="900" cy="520" r="9" />
+    <circle cx="1140" cy="640" r="10" />
+  </g>
+</svg>

--- a/tekgurus-theme/assets/images/insight1.svg
+++ b/tekgurus-theme/assets/images/insight1.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Insight card illustration</title>
+  <desc id="desc">Abstract shapes with TekGurus colors representing insights.</desc>
+  <defs>
+    <linearGradient id="insightGradient1" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#101014" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" rx="28" fill="url(#insightGradient1)" />
+  <path d="M80 320 C160 260, 240 340, 320 280 S480 220, 560 300" stroke="#ffffff" stroke-opacity="0.4" stroke-width="8" fill="none" stroke-linecap="round" />
+  <circle cx="160" cy="180" r="36" fill="#ffffff" fill-opacity="0.65" />
+  <circle cx="440" cy="150" r="52" fill="#ffffff" fill-opacity="0.35" />
+</svg>

--- a/tekgurus-theme/assets/images/insight2.svg
+++ b/tekgurus-theme/assets/images/insight2.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Insight card illustration</title>
+  <desc id="desc">Diagonal blocks with red and black gradient.</desc>
+  <defs>
+    <linearGradient id="insightGradient2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#18181c" />
+      <stop offset="100%" stop-color="#f23d42" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" rx="28" fill="url(#insightGradient2)" />
+  <path d="M0 280 L220 120 L420 280 L640 120 V400 H0 Z" fill="#ffffff" fill-opacity="0.12" />
+  <circle cx="520" cy="280" r="40" fill="#ffffff" fill-opacity="0.5" />
+  <circle cx="200" cy="140" r="26" fill="#ffffff" fill-opacity="0.35" />
+</svg>

--- a/tekgurus-theme/assets/images/insight3.svg
+++ b/tekgurus-theme/assets/images/insight3.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Insight card illustration</title>
+  <desc id="desc">Network of nodes over a gradient background.</desc>
+  <defs>
+    <linearGradient id="insightGradient3" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0f0f11" />
+      <stop offset="100%" stop-color="#d92d31" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" rx="28" fill="url(#insightGradient3)" />
+  <g stroke="#ffffff" stroke-opacity="0.3" stroke-width="3" fill="none">
+    <path d="M100 120 L220 200 L340 120 L460 200 L580 120" />
+    <path d="M100 280 L220 200 L340 280 L460 200 L580 280" />
+  </g>
+  <g fill="#ffffff" fill-opacity="0.6">
+    <circle cx="100" cy="120" r="12" />
+    <circle cx="220" cy="200" r="10" />
+    <circle cx="340" cy="120" r="12" />
+    <circle cx="460" cy="200" r="10" />
+    <circle cx="580" cy="120" r="12" />
+  </g>
+</svg>

--- a/tekgurus-theme/assets/images/insight4.svg
+++ b/tekgurus-theme/assets/images/insight4.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Case study illustration</title>
+  <desc id="desc">Layered shapes showing transformation paths.</desc>
+  <defs>
+    <linearGradient id="insightGradient4" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#121219" />
+      <stop offset="100%" stop-color="#ef3a40" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" rx="28" fill="url(#insightGradient4)" />
+  <path d="M80 320 L200 200 L320 320 L440 200 L560 320" stroke="#ffffff" stroke-opacity="0.35" stroke-width="12" fill="none" stroke-linecap="round" />
+  <rect x="120" y="120" width="160" height="80" rx="18" fill="#ffffff" fill-opacity="0.22" />
+  <rect x="360" y="160" width="160" height="80" rx="18" fill="#ffffff" fill-opacity="0.18" />
+</svg>

--- a/tekgurus-theme/assets/images/insight5.svg
+++ b/tekgurus-theme/assets/images/insight5.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Case study illustration</title>
+  <desc id="desc">Diagonal gradient blocks symbolizing growth.</desc>
+  <defs>
+    <linearGradient id="insightGradient5" x1="100%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#15151b" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" rx="28" fill="url(#insightGradient5)" />
+  <path d="M40 280 L200 200 L320 300 L480 200 L600 260" fill="none" stroke="#ffffff" stroke-width="10" stroke-linecap="round" stroke-opacity="0.35" />
+  <circle cx="200" cy="200" r="18" fill="#ffffff" fill-opacity="0.6" />
+  <circle cx="320" cy="300" r="20" fill="#ffffff" fill-opacity="0.45" />
+  <circle cx="480" cy="200" r="18" fill="#ffffff" fill-opacity="0.6" />
+</svg>

--- a/tekgurus-theme/assets/images/insight6.svg
+++ b/tekgurus-theme/assets/images/insight6.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400" role="img" aria-labelledby="title desc">
+  <title id="title">Case study illustration</title>
+  <desc id="desc">Stacked rectangles symbolizing structured insights.</desc>
+  <defs>
+    <linearGradient id="insightGradient6" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#16161b" />
+      <stop offset="100%" stop-color="#ff4d54" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="400" rx="28" fill="url(#insightGradient6)" />
+  <rect x="120" y="120" width="400" height="40" rx="12" fill="#ffffff" fill-opacity="0.3" />
+  <rect x="160" y="200" width="360" height="40" rx="12" fill="#ffffff" fill-opacity="0.4" />
+  <rect x="200" y="280" width="280" height="40" rx="12" fill="#ffffff" fill-opacity="0.35" />
+</svg>

--- a/tekgurus-theme/assets/images/leader1.svg
+++ b/tekgurus-theme/assets/images/leader1.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 480" role="img" aria-labelledby="title desc">
+  <title id="title">Portrait placeholder</title>
+  <desc id="desc">Abstract portrait illustration with TekGurus colors.</desc>
+  <defs>
+    <linearGradient id="portraitGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#1b1b1f" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="480" rx="32" fill="url(#portraitGradient)" />
+  <circle cx="200" cy="180" r="90" fill="#ffffff" fill-opacity="0.85" />
+  <rect x="120" y="260" width="160" height="140" rx="40" fill="#ffffff" fill-opacity="0.8" />
+  <path d="M120 340 Q200 380 280 340" fill="#e5252a" fill-opacity="0.5" />
+</svg>

--- a/tekgurus-theme/assets/images/leader2.svg
+++ b/tekgurus-theme/assets/images/leader2.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 480" role="img" aria-labelledby="title desc">
+  <title id="title">Portrait placeholder</title>
+  <desc id="desc">Abstract portrait illustration with black and red tones.</desc>
+  <defs>
+    <linearGradient id="portraitGradient2" x1="100%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#191c24" />
+      <stop offset="100%" stop-color="#e5252a" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="480" rx="32" fill="url(#portraitGradient2)" />
+  <circle cx="200" cy="170" r="85" fill="#ffffff" fill-opacity="0.85" />
+  <rect x="120" y="250" width="160" height="150" rx="36" fill="#ffffff" fill-opacity="0.8" />
+  <path d="M120 340 Q200 390 280 340" fill="#000000" fill-opacity="0.35" />
+</svg>

--- a/tekgurus-theme/assets/images/leader3.svg
+++ b/tekgurus-theme/assets/images/leader3.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 480" role="img" aria-labelledby="title desc">
+  <title id="title">Portrait placeholder</title>
+  <desc id="desc">Abstract portrait illustration with warm gradient.</desc>
+  <defs>
+    <linearGradient id="portraitGradient3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#26262b" />
+      <stop offset="100%" stop-color="#f0464c" />
+    </linearGradient>
+  </defs>
+  <rect width="400" height="480" rx="32" fill="url(#portraitGradient3)" />
+  <circle cx="200" cy="180" r="88" fill="#ffffff" fill-opacity="0.9" />
+  <rect x="120" y="260" width="160" height="150" rx="44" fill="#ffffff" fill-opacity="0.8" />
+  <path d="M120 340 Q200 410 280 340" fill="#e5252a" fill-opacity="0.45" />
+</svg>

--- a/tekgurus-theme/assets/images/tekgurus-logo.svg
+++ b/tekgurus-theme/assets/images/tekgurus-logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 120" role="img" aria-labelledby="title desc">
+  <title id="title">TekGurus alliance badge</title>
+  <desc id="desc">TekGurus lettering over a red underline.</desc>
+  <rect width="240" height="120" rx="16" fill="#080809" />
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" font-family="'Poppins', 'Arial', sans-serif" font-size="32" fill="#ffffff">TekGurus</text>
+  <rect x="60" y="78" width="120" height="8" rx="4" fill="#e5252a" />
+</svg>

--- a/tekgurus-theme/assets/logo/tekgurus-logo.svg
+++ b/tekgurus-theme/assets/logo/tekgurus-logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200" role="img" aria-labelledby="title desc">
+  <title id="title">TekGurus logomark</title>
+  <desc id="desc">Stylized TG monogram in TekGurus colors.</desc>
+  <defs>
+    <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#e5252a" />
+      <stop offset="100%" stop-color="#7d1012" />
+    </linearGradient>
+  </defs>
+  <rect width="200" height="200" rx="36" fill="#0d0d10" />
+  <g fill="none" stroke="url(#logoGradient)" stroke-width="16" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M60 70 H140" />
+    <path d="M60 70 V140 C60 160 80 160 100 140" />
+    <path d="M120 70 V140 H150" />
+  </g>
+  <circle cx="160" cy="50" r="12" fill="#ffffff" />
+</svg>

--- a/tekgurus-theme/css/style.css
+++ b/tekgurus-theme/css/style.css
@@ -1,0 +1,447 @@
+/* Global Styles */
+:root {
+    --primary: #e5252a;
+    --dark: #000000;
+    --light: #ffffff;
+}
+
+body {
+    background-color: var(--dark);
+    color: var(--light);
+    font-family: 'Poppins', sans-serif;
+    scroll-behavior: smooth;
+}
+
+.site-header {
+    background: transparent;
+}
+
+.site-header.scrolled {
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.nav-link {
+    position: relative;
+    font-size: 0.9rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(243, 244, 246, 0.85);
+    transition: color 0.3s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+    color: var(--primary);
+}
+
+.nav-link::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -0.75rem;
+    width: 0;
+    height: 2px;
+    background: var(--primary);
+    transition: width 0.3s ease;
+}
+
+.nav-link:hover::after,
+.nav-link:focus::after,
+.nav-link[aria-expanded="true"]::after {
+    width: 100%;
+}
+
+.btn-primary,
+.btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.75rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    transition: all 0.3s ease;
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: var(--light);
+}
+
+.btn-primary:hover {
+    background: rgba(229, 37, 42, 0.8);
+}
+
+.btn-secondary {
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    color: var(--light);
+}
+
+.btn-secondary:hover {
+    border-color: var(--primary);
+    color: var(--primary);
+}
+
+.link-more {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: var(--primary);
+    font-size: 0.95rem;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.link-more::after {
+    content: '›';
+    font-size: 1.1rem;
+}
+
+.link-more:hover {
+    color: rgba(229, 37, 42, 0.8);
+}
+
+.mobile-link {
+    display: block;
+    font-size: 1rem;
+    color: rgba(243, 244, 246, 0.85);
+    transition: color 0.3s ease;
+}
+
+.mobile-link:hover {
+    color: var(--primary);
+}
+
+.mega-menu-wrapper {
+    position: relative;
+}
+
+.mega-menu {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    background: rgba(10, 10, 10, 0.96);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 24px;
+    padding: 2.5rem;
+    transform: translateY(20px);
+    opacity: 0;
+    transition: all 0.3s ease;
+}
+
+.mega-menu.active {
+    display: block;
+    transform: translateY(0);
+    opacity: 1;
+}
+
+.submenu-link {
+    display: block;
+    font-size: 0.95rem;
+    color: rgba(243, 244, 246, 0.8);
+    transition: color 0.3s ease;
+}
+
+.submenu-link:hover {
+    color: var(--primary);
+}
+
+.hero-slider {
+    position: relative;
+    overflow: hidden;
+}
+
+.hero-slide {
+    position: absolute;
+    inset: 0;
+    background-size: cover;
+    background-position: center;
+    opacity: 0;
+    transition: opacity 1s ease;
+}
+
+.hero-slide.active {
+    opacity: 1;
+}
+
+.slider-control {
+    height: 3rem;
+    width: 3rem;
+    border-radius: 9999px;
+    background: rgba(0, 0, 0, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--light);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.3s ease;
+}
+
+.slider-control:hover {
+    background: var(--primary);
+}
+
+.slider-dots button {
+    height: 0.75rem;
+    width: 0.75rem;
+    border-radius: 9999px;
+    background: rgba(255, 255, 255, 0.4);
+    border: none;
+    transition: background 0.3s ease;
+}
+
+.slider-dots button.active {
+    background: var(--primary);
+}
+
+.section-heading {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.4em;
+    font-size: 0.75rem;
+    color: var(--primary);
+}
+
+.section-title {
+    font-size: 2.5rem;
+    font-weight: 600;
+    margin-top: 1rem;
+}
+
+.section-description {
+    margin: 1rem auto 0;
+    color: rgba(209, 213, 219, 0.8);
+    max-width: 48rem;
+}
+
+.card,
+.service-card,
+.solution-card,
+.insight-card,
+.news-card,
+.feature-panel,
+.stat-card,
+.lead-card,
+.approach-step {
+    background: #0f0f0f;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 24px;
+    padding: 2rem;
+    transition: transform 0.3s ease, border 0.3s ease;
+}
+
+.card:hover,
+.service-card:hover,
+.insight-card:hover {
+    transform: translateY(-8px);
+    border-color: rgba(229, 37, 42, 0.5);
+}
+
+.card-title,
+.service-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.card-text,
+.service-text {
+    color: rgba(209, 213, 219, 0.85);
+    font-size: 0.95rem;
+    line-height: 1.7;
+}
+
+.feature-panel,
+.stat-card {
+    background: #111111;
+}
+
+.lead-card {
+    overflow: hidden;
+    padding: 0;
+}
+
+.lead-photo {
+    width: 100%;
+    height: 16rem;
+    object-fit: cover;
+}
+
+.lead-card .p-6 {
+    padding: 1.5rem;
+}
+
+.approach-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 1rem;
+}
+
+.approach-step .step-index {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--primary);
+}
+
+.service-icon {
+    height: 3rem;
+    width: 3rem;
+    border-radius: 9999px;
+    background: rgba(229, 37, 42, 0.2);
+    color: var(--primary);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+}
+
+.solution-list {
+    list-style: disc;
+    padding-left: 1rem;
+    color: rgba(209, 213, 219, 0.85);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.solution-highlight {
+    background: #111111;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 24px;
+    padding: 1.5rem;
+}
+
+.insight-card {
+    overflow: hidden;
+}
+
+.insight-image {
+    width: 100%;
+    height: 13rem;
+    object-fit: cover;
+}
+
+.news-card {
+    background: #111111;
+}
+
+.contact-icon {
+    font-size: 1.3rem;
+}
+
+.form-label {
+    display: block;
+    font-size: 0.65rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.9);
+    margin-bottom: 0.5rem;
+}
+
+.form-input,
+.form-input:focus,
+.form-input:active,
+form select,
+form textarea {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: rgba(0, 0, 0, 0.6);
+    color: var(--light);
+    outline: none;
+    transition: border 0.3s ease;
+}
+
+.form-input:focus,
+form select:focus,
+form textarea:focus {
+    border-color: var(--primary);
+}
+
+.social-link {
+    color: rgba(209, 213, 219, 0.7);
+    transition: color 0.3s ease;
+}
+
+.social-link:hover {
+    color: var(--primary);
+}
+
+.footer-title {
+    font-size: 0.75rem;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: rgba(148, 163, 184, 0.8);
+    margin-bottom: 1rem;
+}
+
+.footer-links {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    color: rgba(209, 213, 219, 0.8);
+    font-size: 0.95rem;
+}
+
+.footer-links a {
+    color: rgba(209, 213, 219, 0.85);
+    transition: color 0.3s ease;
+}
+
+.footer-links a:hover {
+    color: var(--primary);
+}
+
+/* Animations */
+[data-animate] {
+    opacity: 0;
+    transform: translateY(30px);
+    transition: opacity 0.8s ease, transform 0.8s ease;
+}
+
+[data-animate].visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.animate-fade-in {
+    animation: fadeInUp 1.2s ease forwards;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(30px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Responsive Adjustments */
+@media (max-width: 1024px) {
+    .mega-menu-wrapper {
+        display: none;
+    }
+}
+
+@media (max-width: 768px) {
+    .section-title {
+        font-size: 2rem;
+    }
+
+    .hero-slider {
+        height: 80vh;
+    }
+}

--- a/tekgurus-theme/footer.php
+++ b/tekgurus-theme/footer.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Footer template.
+ *
+ * @package TekGurus
+ */
+?>
+</main>
+<section class="py-24 bg-dark" id="deliver">
+    <div class="max-w-7xl mx-auto px-6">
+        <div class="section-heading">
+            <p class="eyebrow"><?php esc_html_e( 'What We Deliver', 'tekgurus' ); ?></p>
+            <h2 class="section-title"><?php esc_html_e( 'Cloud programs that accelerate progress', 'tekgurus' ); ?></h2>
+            <p class="section-description"><?php esc_html_e( 'Our multidisciplinary team partners with you to design, deploy, and evolve secure platforms with measurable value at every stage.', 'tekgurus' ); ?></p>
+        </div>
+        <div class="grid gap-8 md:grid-cols-2 xl:grid-cols-4">
+            <div class="stat-card" data-animate>
+                <h3 class="text-4xl font-semibold text-primary">90%</h3>
+                <p class="mt-3 text-gray-300"><?php esc_html_e( 'Faster release cycles through automated CI/CD and DevOps practices.', 'tekgurus' ); ?></p>
+            </div>
+            <div class="stat-card" data-animate>
+                <h3 class="text-4xl font-semibold text-primary">40%</h3>
+                <p class="mt-3 text-gray-300"><?php esc_html_e( 'Average cost optimization achieved across managed cloud engagements.', 'tekgurus' ); ?></p>
+            </div>
+            <div class="stat-card" data-animate>
+                <h3 class="text-4xl font-semibold text-primary">99.99%</h3>
+                <p class="mt-3 text-gray-300"><?php esc_html_e( 'Resilience engineered with multi-region architectures and governance.', 'tekgurus' ); ?></p>
+            </div>
+            <div class="stat-card" data-animate>
+                <h3 class="text-4xl font-semibold text-primary">24/7</h3>
+                <p class="mt-3 text-gray-300"><?php esc_html_e( 'Partnership that extends beyond go-live with continuous improvement cycles.', 'tekgurus' ); ?></p>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="py-20 bg-[#0f0f0f]">
+    <div class="max-w-6xl mx-auto px-6">
+        <div class="flex flex-wrap items-center justify-between gap-10 opacity-70" data-animate>
+            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/aws-logo.svg' ); ?>" alt="<?php esc_attr_e( 'AWS Partner', 'tekgurus' ); ?>" class="h-12 object-contain">
+            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/azure-logo.svg' ); ?>" alt="<?php esc_attr_e( 'Azure Partner', 'tekgurus' ); ?>" class="h-12 object-contain">
+            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/gcp-logo.svg' ); ?>" alt="<?php esc_attr_e( 'Google Cloud Partner', 'tekgurus' ); ?>" class="h-12 object-contain">
+            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/tekgurus-logo.svg' ); ?>" alt="<?php esc_attr_e( 'TekGurus Alliance', 'tekgurus' ); ?>" class="h-12 object-contain">
+        </div>
+    </div>
+</section>
+<footer class="bg-black border-t border-white/5">
+    <div class="max-w-7xl mx-auto px-6 py-16 grid md:grid-cols-4 gap-10">
+        <div class="space-y-4">
+            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/logo/tekgurus-logo.svg' ); ?>" alt="<?php esc_attr_e( 'TekGurus logo', 'tekgurus' ); ?>" class="h-14 w-auto object-contain">
+            <p class="text-gray-400"><?php esc_html_e( 'TekGurus designs cloud experiences that empower people, streamline operations, and unleash innovation for Africa’s leading organizations.', 'tekgurus' ); ?></p>
+        </div>
+        <div>
+            <h4 class="footer-title"><?php esc_html_e( 'Company', 'tekgurus' ); ?></h4>
+            <ul class="footer-links">
+                <li><a href="<?php echo esc_url( home_url( '/about/' ) ); ?>"><?php esc_html_e( 'About', 'tekgurus' ); ?></a></li>
+                <li><a href="<?php echo esc_url( home_url( '/services/' ) ); ?>"><?php esc_html_e( 'Services', 'tekgurus' ); ?></a></li>
+                <li><a href="<?php echo esc_url( home_url( '/solutions/' ) ); ?>"><?php esc_html_e( 'Solutions', 'tekgurus' ); ?></a></li>
+                <li><a href="<?php echo esc_url( home_url( '/insights/' ) ); ?>"><?php esc_html_e( 'Insights', 'tekgurus' ); ?></a></li>
+                <li><a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>"><?php esc_html_e( 'Contact', 'tekgurus' ); ?></a></li>
+            </ul>
+        </div>
+        <div>
+            <h4 class="footer-title"><?php esc_html_e( 'Contact', 'tekgurus' ); ?></h4>
+            <ul class="footer-links">
+                <li><?php esc_html_e( '7 Ibiyinka Olorunbe, VI, Lagos, Nigeria', 'tekgurus' ); ?></li>
+                <li><a href="mailto:info@thetekgurus.com">info@thetekgurus.com</a></li>
+                <li><a href="tel:+2349049206989">+234 904 920 6989</a></li>
+            </ul>
+        </div>
+        <div>
+            <h4 class="footer-title"><?php esc_html_e( 'Follow', 'tekgurus' ); ?></h4>
+            <div class="flex space-x-4 text-gray-400">
+                <a href="#" aria-label="LinkedIn" class="social-link">
+                    <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M4.98 3.5a2.5 2.5 0 11-.01 5.001 2.5 2.5 0 01-.01-5.001zM3 9h4v12H3zM9 9h3.8v1.71h.05c.53-1.82 2.05-3.75 3.75-3.75 4.01 0 4.75 2.64 4.75 6.07V21H17v-5.4c0-1.29-.03-2.95-1.8-2.95-1.8 0-2.07 1.4-2.07 2.85V21H9z" />
+                    </svg>
+                </a>
+                <a href="#" aria-label="Twitter" class="social-link">
+                    <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M22.46 6c-.77.35-1.6.58-2.46.69a4.22 4.22 0 001.84-2.33 8.4 8.4 0 01-2.67 1.03 4.2 4.2 0 00-7.15 3.83A11.92 11.92 0 013 5.16a4.2 4.2 0 001.3 5.6 4.15 4.15 0 01-1.9-.52v.05a4.2 4.2 0 003.37 4.12 4.3 4.3 0 01-1.1.15c-.27 0-.54-.03-.8-.07a4.21 4.21 0 003.92 2.91A8.45 8.45 0 012 19.54a11.89 11.89 0 006.44 1.89c7.73 0 11.96-6.41 11.96-11.97 0-.18 0-.36-.01-.54A8.54 8.54 0 0024 5.5a8.4 8.4 0 01-2.54.7z" />
+                    </svg>
+                </a>
+                <a href="#" aria-label="Instagram" class="social-link">
+                    <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M7 2C4.24 2 2 4.24 2 7v10c0 2.76 2.24 5 5 5h10c2.76 0 5-2.24 5-5V7c0-2.76-2.24-5-5-5H7zm10 2c1.66 0 3 1.34 3 3v10c0 1.66-1.34 3-3 3H7c-1.66 0-3-1.34-3-3V7c0-1.66 1.34-3 3-3h10zm-5 3a5 5 0 100 10 5 5 0 000-10zm0 2c1.66 0 3 1.34 3 3s-1.34 3-3 3a3 3 0 110-6zm4.5-.75a1.25 1.25 0 100 2.5 1.25 1.25 0 000-2.5z" />
+                    </svg>
+                </a>
+                <a href="#" aria-label="YouTube" class="social-link">
+                    <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                        <path d="M21.8 8s-.2-1.4-.8-2c-.8-.8-1.7-.8-2.1-.9C15.7 4.7 12 4.7 12 4.7h0s-3.7 0-6.9.4c-.4.1-1.3.1-2.1.9-.6.6-.8 2-.8 2S2 9.6 2 11.2v1.6C2 14.4 2.2 16 2.2 16s.2 1.4.8 2c.8.8 1.8.7 2.3.8 1.7.2 7 .4 7 .4s3.7 0 6.9-.4c.4-.1 1.3-.1 2.1-.9.6-.6.8-2 .8-2s.2-1.6.2-3.2v-1.6c0-1.6-.2-3.2-.2-3.2zM10 14.7V9.3l5 2.7-5 2.7z" />
+                    </svg>
+                </a>
+            </div>
+        </div>
+    </div>
+    <div class="border-t border-white/5 py-6 text-center text-gray-500 text-sm">© <?php echo esc_html( gmdate( 'Y' ) ); ?> <?php bloginfo( 'name' ); ?>. <?php esc_html_e( 'All Rights Reserved.', 'tekgurus' ); ?></div>
+</footer>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/tekgurus-theme/front-page.php
+++ b/tekgurus-theme/front-page.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Front page template.
+ *
+ * @package TekGurus
+ */
+get_header();
+?>
+<?php if ( have_posts() ) : ?>
+    <?php while ( have_posts() ) : the_post(); ?>
+        <?php
+        $has_custom_content = ( function_exists( 'has_blocks' ) && has_blocks( get_the_ID() ) ) || strlen( trim( wp_strip_all_tags( get_the_content() ) ) ) > 0;
+        ?>
+        <?php if ( $has_custom_content ) : ?>
+            <div class="container mx-auto px-6 py-12 content-area">
+                <?php the_content(); ?>
+            </div>
+        <?php else : ?>
+            <section class="hero-slider relative h-screen">
+                <div class="absolute inset-0">
+                    <div class="hero-slide" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero1.svg' ); ?>');"></div>
+                    <div class="hero-slide" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero2.svg' ); ?>');"></div>
+                    <div class="hero-slide" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero3.svg' ); ?>');"></div>
+                    <div class="hero-slide" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero4.svg' ); ?>');"></div>
+                </div>
+                <div class="relative z-10 h-full flex items-center bg-black/50">
+                    <div class="max-w-7xl mx-auto px-6">
+                        <div class="max-w-2xl space-y-6 animate-fade-in">
+                            <p class="uppercase tracking-[0.5em] text-sm text-gray-300"><?php esc_html_e( 'Cloud. People. Possibility.', 'tekgurus' ); ?></p>
+                            <h1 class="text-4xl md:text-6xl font-semibold leading-tight"><?php esc_html_e( 'Empowering Businesses with Intelligent Cloud Solutions', 'tekgurus' ); ?></h1>
+                            <p class="text-lg text-gray-200"><?php esc_html_e( 'TekGurus aligns strategy, engineering, and enablement to unlock resilient cloud experiences that scale with ambition.', 'tekgurus' ); ?></p>
+                            <div class="flex flex-wrap items-center gap-4">
+                                <a href="<?php echo esc_url( home_url( '/services/' ) ); ?>" class="btn-primary"><?php esc_html_e( 'Explore Our Services', 'tekgurus' ); ?></a>
+                                <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="btn-secondary"><?php esc_html_e( 'Schedule a Consultation', 'tekgurus' ); ?></a>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="absolute bottom-8 left-1/2 -translate-x-1/2 z-10 flex items-center space-x-3">
+                    <button class="slider-control" data-direction="prev" aria-label="<?php esc_attr_e( 'Previous slide', 'tekgurus' ); ?>">
+                        <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+                        </svg>
+                    </button>
+                    <div class="slider-dots flex space-x-2"></div>
+                    <button class="slider-control" data-direction="next" aria-label="<?php esc_attr_e( 'Next slide', 'tekgurus' ); ?>">
+                        <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                        </svg>
+                    </button>
+                </div>
+            </section>
+            <section class="py-24 bg-dark" id="expertise">
+                <div class="max-w-7xl mx-auto px-6">
+                    <div class="section-heading">
+                        <p class="eyebrow"><?php esc_html_e( 'Our Expertise', 'tekgurus' ); ?></p>
+                        <h2 class="section-title"><?php esc_html_e( 'Cloud-native leadership with a human heartbeat', 'tekgurus' ); ?></h2>
+                        <p class="section-description"><?php esc_html_e( 'From advisory through operations, TekGurus co-creates modern cloud foundations that are secure, adaptive, and future-ready.', 'tekgurus' ); ?></p>
+                    </div>
+                    <div class="grid gap-10 md:grid-cols-3">
+                        <div class="card" data-animate>
+                            <h3 class="card-title"><?php esc_html_e( 'Strategic Advisory', 'tekgurus' ); ?></h3>
+                            <p class="card-text"><?php esc_html_e( 'Align every initiative with a clear cloud vision. We translate ambition into actionable roadmaps anchored in governance, adoption, and culture.', 'tekgurus' ); ?></p>
+                        </div>
+                        <div class="card" data-animate>
+                            <h3 class="card-title"><?php esc_html_e( 'Engineering Excellence', 'tekgurus' ); ?></h3>
+                            <p class="card-text"><?php esc_html_e( 'Deploy scalable architectures across hyperscalers. Our engineers build with automation, resilience, and performance at the core.', 'tekgurus' ); ?></p>
+                        </div>
+                        <div class="card" data-animate>
+                            <h3 class="card-title"><?php esc_html_e( 'Enablement & Support', 'tekgurus' ); ?></h3>
+                            <p class="card-text"><?php esc_html_e( 'Empower your teams with playbooks, training, and co-managed operations designed to elevate collaboration and maintain momentum.', 'tekgurus' ); ?></p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <section class="py-24 bg-[#0a0a0a]">
+                <div class="max-w-7xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-center">
+                    <div class="space-y-6" data-animate>
+                        <p class="eyebrow"><?php esc_html_e( 'Why Choose TekGurus', 'tekgurus' ); ?></p>
+                        <h2 class="section-title"><?php esc_html_e( 'We orchestrate technology and people for measurable impact', 'tekgurus' ); ?></h2>
+                        <p class="text-gray-300 leading-relaxed"><?php esc_html_e( 'Our consultants embed within your teams to co-create operating models that drive sustainable transformation. TekGurus combines modern tooling with proven governance to help enterprises stay secure, agile, and connected.', 'tekgurus' ); ?></p>
+                        <div class="grid grid-cols-2 gap-6 text-sm">
+                            <div>
+                                <h4 class="font-semibold text-light"><?php esc_html_e( 'Certified Cloud Architects', 'tekgurus' ); ?></h4>
+                                <p class="text-gray-400 mt-2"><?php esc_html_e( 'Experts across AWS, Azure, and Google Cloud with deep sector insight.', 'tekgurus' ); ?></p>
+                            </div>
+                            <div>
+                                <h4 class="font-semibold text-light"><?php esc_html_e( 'Customer-Obsessed Delivery', 'tekgurus' ); ?></h4>
+                                <p class="text-gray-400 mt-2"><?php esc_html_e( 'Engagement models tailored to your pace, culture, and growth trajectory.', 'tekgurus' ); ?></p>
+                            </div>
+                            <div>
+                                <h4 class="font-semibold text-light"><?php esc_html_e( 'Security at the Core', 'tekgurus' ); ?></h4>
+                                <p class="text-gray-400 mt-2"><?php esc_html_e( 'Zero-trust frameworks and governance blueprints built into every project.', 'tekgurus' ); ?></p>
+                            </div>
+                            <div>
+                                <h4 class="font-semibold text-light"><?php esc_html_e( 'Innovation Accelerated', 'tekgurus' ); ?></h4>
+                                <p class="text-gray-400 mt-2"><?php esc_html_e( 'Automation, AI, and DevOps practices that unlock new digital value.', 'tekgurus' ); ?></p>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="grid gap-6" data-animate>
+                        <div class="feature-panel">
+                            <h3 class="text-xl font-semibold text-light"><?php esc_html_e( 'Experience-led transformation', 'tekgurus' ); ?></h3>
+                            <p class="text-gray-300 mt-3"><?php esc_html_e( 'We guide stakeholders through immersive workshops, co-innovation labs, and product roadmaps that turn strategy into delivery.', 'tekgurus' ); ?></p>
+                        </div>
+                        <div class="feature-panel">
+                            <h3 class="text-xl font-semibold text-light"><?php esc_html_e( 'Proactive managed services', 'tekgurus' ); ?></h3>
+                            <p class="text-gray-300 mt-3"><?php esc_html_e( '24/7 observability and incident response, tuned to your SLAs and optimized for continuous improvement.', 'tekgurus' ); ?></p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        <?php endif; ?>
+    <?php endwhile; ?>
+<?php endif; ?>
+<?php
+get_footer();

--- a/tekgurus-theme/functions.php
+++ b/tekgurus-theme/functions.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * Theme setup and asset loading.
+ */
+
+define( 'TEKGURUS_VERSION', '1.0.0' );
+
+define( 'TEKGURUS_THEME_DIR', get_template_directory() );
+define( 'TEKGURUS_THEME_URI', get_template_directory_uri() );
+
+add_action( 'after_setup_theme', 'tekgurus_setup' );
+/**
+ * Configure theme defaults and register support for WordPress features.
+ */
+function tekgurus_setup() {
+    add_theme_support( 'title-tag' );
+    add_theme_support( 'post-thumbnails' );
+    add_theme_support( 'menus' );
+    add_theme_support( 'bricks' );
+    add_theme_support( 'align-wide' );
+
+    register_nav_menus(
+        array(
+            'primary' => __( 'Primary Menu', 'tekgurus' ),
+            'mobile'  => __( 'Mobile Menu', 'tekgurus' ),
+        )
+    );
+}
+
+add_action( 'wp_enqueue_scripts', 'tekgurus_enqueue_assets' );
+/**
+ * Load frontend assets.
+ */
+function tekgurus_enqueue_assets() {
+    wp_enqueue_style( 'tekgurus-google-fonts', 'https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap', array(), null );
+    wp_enqueue_script( 'tekgurus-tailwind', 'https://cdn.tailwindcss.com', array(), null, false );
+
+    $tailwind_config = 'tailwind.config = { theme: { extend: { colors: { primary: "#e5252a", dark: "#000000", light: "#ffffff" }, fontFamily: { sans: ["Poppins", "sans-serif"] } } } };';
+    wp_add_inline_script( 'tekgurus-tailwind', $tailwind_config, 'after' );
+
+    wp_enqueue_style( 'tekgurus-style', TEKGURUS_THEME_URI . '/style.css', array( 'tekgurus-google-fonts' ), TEKGURUS_VERSION );
+    wp_enqueue_script( 'tekgurus-main', TEKGURUS_THEME_URI . '/js/main.js', array(), TEKGURUS_VERSION, true );
+}
+
+add_filter( 'body_class', 'tekgurus_body_classes' );
+/**
+ * Add custom body classes.
+ *
+ * @param array $classes Existing classes.
+ * @return array
+ */
+function tekgurus_body_classes( $classes ) {
+    $classes[] = 'bg-dark';
+    $classes[] = 'text-light';
+    $classes[] = 'font-sans';
+    return $classes;
+}
+
+add_filter( 'nav_menu_css_class', 'tekgurus_add_nav_link_class', 10, 4 );
+/**
+ * Apply nav link classes to menu items for styling parity.
+ *
+ * @param array  $classes Existing classes.
+ * @param object $item    Menu item.
+ * @param object $args    Menu arguments.
+ * @param int    $depth   Depth level.
+ * @return array
+ */
+function tekgurus_add_nav_link_class( $classes, $item, $args, $depth ) {
+    return array_unique( $classes );
+}
+
+add_filter( 'nav_menu_link_attributes', 'tekgurus_add_nav_link_attributes', 10, 4 );
+/**
+ * Add data attributes required for mega menu interactions.
+ *
+ * @param array  $atts  Link attributes.
+ * @param object $item  Menu item object.
+ * @param object $args  Menu args.
+ * @param int    $depth Depth level.
+ * @return array
+ */
+function tekgurus_add_nav_link_attributes( $atts, $item, $args, $depth ) {
+    if ( isset( $args->theme_location ) && 'primary' === $args->theme_location ) {
+        if ( 0 === $depth ) {
+            $slug                    = sanitize_title( $item->title );
+            $atts['data-menu-target'] = $slug;
+            $atts['aria-haspopup']    = 'true';
+            $atts['aria-expanded']    = 'false';
+            $atts['class']            = isset( $atts['class'] ) ? $atts['class'] . ' nav-link' : 'nav-link';
+        } else {
+            $atts['class'] = isset( $atts['class'] ) ? $atts['class'] . ' submenu-link' : 'submenu-link';
+        }
+    }
+
+    if ( isset( $args->theme_location ) && 'mobile' === $args->theme_location ) {
+        $atts['class'] = isset( $atts['class'] ) ? $atts['class'] . ' mobile-link' : 'mobile-link';
+    }
+
+    return $atts;
+}
+
+add_action( 'after_setup_theme', 'tekgurus_register_bricks_locations' );
+/**
+ * Register header and footer locations for Bricks Builder templates if the plugin is active.
+ */
+function tekgurus_register_bricks_locations() {
+    if ( function_exists( 'bricks_register_theme_locations' ) ) {
+        bricks_register_theme_locations(
+            array(
+                'header' => __( 'Header', 'tekgurus' ),
+                'footer' => __( 'Footer', 'tekgurus' ),
+            )
+        );
+    }
+}
+
+/**
+ * Fallback mobile menu replicating static structure if no menu is assigned.
+ */
+function tekgurus_mobile_menu_fallback() {
+    $links = array(
+        array(
+            'label' => __( 'Overview', 'tekgurus' ),
+            'url'   => home_url( '/about/' ),
+        ),
+        array(
+            'label' => __( 'Mission & Vision', 'tekgurus' ),
+            'url'   => home_url( '/about/#mission' ),
+        ),
+        array(
+            'label' => __( 'Leadership', 'tekgurus' ),
+            'url'   => home_url( '/about/#leadership' ),
+        ),
+        array(
+            'label' => __( 'Our Approach', 'tekgurus' ),
+            'url'   => home_url( '/about/#approach' ),
+        ),
+        array(
+            'label' => __( 'Cloud Strategy & Advisory', 'tekgurus' ),
+            'url'   => home_url( '/services/#strategy' ),
+        ),
+        array(
+            'label' => __( 'Implementation & Migration', 'tekgurus' ),
+            'url'   => home_url( '/services/#implementation' ),
+        ),
+        array(
+            'label' => __( 'Security & Governance', 'tekgurus' ),
+            'url'   => home_url( '/services/#security' ),
+        ),
+        array(
+            'label' => __( 'Optimization & Automation', 'tekgurus' ),
+            'url'   => home_url( '/services/#optimization' ),
+        ),
+        array(
+            'label' => __( 'Managed Services', 'tekgurus' ),
+            'url'   => home_url( '/services/#managed' ),
+        ),
+        array(
+            'label' => __( 'Training & Enablement', 'tekgurus' ),
+            'url'   => home_url( '/services/#training' ),
+        ),
+        array(
+            'label' => __( 'Hybrid & Multi-Cloud', 'tekgurus' ),
+            'url'   => home_url( '/solutions/#hybrid' ),
+        ),
+        array(
+            'label' => __( 'AI Automation', 'tekgurus' ),
+            'url'   => home_url( '/solutions/#automation' ),
+        ),
+        array(
+            'label' => __( 'Data Analytics', 'tekgurus' ),
+            'url'   => home_url( '/solutions/#analytics' ),
+        ),
+        array(
+            'label' => __( 'Digital Transformation', 'tekgurus' ),
+            'url'   => home_url( '/solutions/#transformation' ),
+        ),
+        array(
+            'label' => __( 'Industry Solutions', 'tekgurus' ),
+            'url'   => home_url( '/solutions/#industry' ),
+        ),
+        array(
+            'label' => __( 'Blogs', 'tekgurus' ),
+            'url'   => home_url( '/insights/#blogs' ),
+        ),
+        array(
+            'label' => __( 'News', 'tekgurus' ),
+            'url'   => home_url( '/insights/#news' ),
+        ),
+        array(
+            'label' => __( 'Case Studies', 'tekgurus' ),
+            'url'   => home_url( '/insights/#cases' ),
+        ),
+        array(
+            'label' => __( 'Contact TekGurus', 'tekgurus' ),
+            'url'   => home_url( '/contact/' ),
+        ),
+        array(
+            'label' => __( '+234 904 920 6989', 'tekgurus' ),
+            'url'   => 'tel:+2349049206989',
+        ),
+        array(
+            'label' => __( 'info@thetekgurus.com', 'tekgurus' ),
+            'url'   => 'mailto:info@thetekgurus.com',
+        ),
+    );
+    echo '<ul class="space-y-2 flex flex-col">';
+    foreach ( $links as $link ) {
+        echo '<li>';
+        printf(
+            '<a class="mobile-link" href="%1$s">%2$s</a>',
+            esc_url( $link['url'] ),
+            esc_html( $link['label'] )
+        );
+        echo '</li>';
+    }
+    echo '</ul>';
+}

--- a/tekgurus-theme/header.php
+++ b/tekgurus-theme/header.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Header template.
+ *
+ * @package TekGurus
+ */
+?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo( 'charset' ); ?>">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<header class="site-header fixed top-0 left-0 w-full z-50 transition-colors duration-300">
+    <div class="max-w-7xl mx-auto px-6">
+        <div class="flex items-center justify-between h-20">
+            <a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="flex items-center space-x-3">
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/logo/tekgurus-logo.svg' ); ?>" alt="<?php esc_attr_e( 'TekGurus logo', 'tekgurus' ); ?>" class="h-12 w-auto object-contain">
+                <span class="text-xl font-semibold tracking-wide uppercase"><?php bloginfo( 'name' ); ?></span>
+            </a>
+            <nav class="hidden lg:flex items-center space-x-8">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'flex items-center space-x-8',
+                        'container'      => false,
+                        'fallback_cb'    => false,
+                    )
+                );
+                ?>
+            </nav>
+            <div class="hidden lg:block">
+                <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="btn-primary"><?php esc_html_e( 'Talk to Our Experts', 'tekgurus' ); ?></a>
+            </div>
+            <button class="lg:hidden text-light" id="mobile-menu-toggle" aria-label="<?php esc_attr_e( 'Toggle navigation', 'tekgurus' ); ?>">
+                <span class="sr-only"><?php esc_html_e( 'Open Menu', 'tekgurus' ); ?></span>
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+            </button>
+        </div>
+    </div>
+    <div class="mega-menu-wrapper hidden lg:block">
+        <div class="max-w-7xl mx-auto px-6">
+            <div class="relative">
+                <div class="mega-menu" data-menu="about">
+                    <div class="grid grid-cols-4 gap-8">
+                        <div class="col-span-2 space-y-4">
+                            <h3 class="text-2xl font-semibold"><?php esc_html_e( 'Discover TekGurus', 'tekgurus' ); ?></h3>
+                            <p class="text-sm leading-relaxed text-gray-200"><?php esc_html_e( 'We build resilient cloud ecosystems that move with the pace of your ambitions, pairing advanced engineering with human-centered insight.', 'tekgurus' ); ?></p>
+                            <a href="<?php echo esc_url( home_url( '/about/' ) ); ?>" class="link-more"><?php esc_html_e( 'Explore our story', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1 space-y-3">
+                            <a href="<?php echo esc_url( home_url( '/about/#mission' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Mission & Vision', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/about/#values' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Core Values', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/about/#leadership' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Leadership', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/about/#approach' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Our Approach', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1">
+                            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero1.svg' ); ?>" alt="<?php esc_attr_e( 'About TekGurus', 'tekgurus' ); ?>" class="rounded-xl w-full h-full object-cover">
+                        </div>
+                    </div>
+                </div>
+                <div class="mega-menu" data-menu="services">
+                    <div class="grid grid-cols-4 gap-8">
+                        <div class="col-span-2 space-y-4">
+                            <h3 class="text-2xl font-semibold"><?php esc_html_e( 'Services crafted for modern teams', 'tekgurus' ); ?></h3>
+                            <p class="text-sm leading-relaxed text-gray-200"><?php esc_html_e( 'From strategy to enablement, TekGurus orchestrates every layer of your cloud journey with clarity, security, and measurable impact.', 'tekgurus' ); ?></p>
+                            <a href="<?php echo esc_url( home_url( '/services/' ) ); ?>" class="link-more"><?php esc_html_e( 'View all services', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1 space-y-3">
+                            <a href="<?php echo esc_url( home_url( '/services/#strategy' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Cloud Strategy & Advisory', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/services/#implementation' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Implementation & Migration', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/services/#security' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Security & Governance', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/services/#optimization' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Optimization & Automation', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/services/#managed' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Managed Cloud Services', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/services/#training' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Training & Enablement', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1">
+                            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero2.svg' ); ?>" alt="<?php esc_attr_e( 'TekGurus services', 'tekgurus' ); ?>" class="rounded-xl w-full h-full object-cover">
+                        </div>
+                    </div>
+                </div>
+                <div class="mega-menu" data-menu="solutions">
+                    <div class="grid grid-cols-4 gap-8">
+                        <div class="col-span-2 space-y-4">
+                            <h3 class="text-2xl font-semibold"><?php esc_html_e( 'Solutions engineered for scale', 'tekgurus' ); ?></h3>
+                            <p class="text-sm leading-relaxed text-gray-200"><?php esc_html_e( 'Activate hybrid agility, AI-powered automation, and data-rich insights that accelerate transformation across your organization.', 'tekgurus' ); ?></p>
+                            <a href="<?php echo esc_url( home_url( '/solutions/' ) ); ?>" class="link-more"><?php esc_html_e( 'Discover our solutions', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1 space-y-3">
+                            <a href="<?php echo esc_url( home_url( '/solutions/#hybrid' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Hybrid & Multi-Cloud', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/solutions/#automation' ) ); ?>" class="submenu-link"><?php esc_html_e( 'AI-Powered Automation', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/solutions/#analytics' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Data Analytics & Insights', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/solutions/#transformation' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Digital Transformation', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/solutions/#industry' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Industry Solutions', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1">
+                            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero3.svg' ); ?>" alt="<?php esc_attr_e( 'TekGurus solutions', 'tekgurus' ); ?>" class="rounded-xl w-full h-full object-cover">
+                        </div>
+                    </div>
+                </div>
+                <div class="mega-menu" data-menu="insights">
+                    <div class="grid grid-cols-4 gap-8">
+                        <div class="col-span-2 space-y-4">
+                            <h3 class="text-2xl font-semibold"><?php esc_html_e( 'Insights to keep you ahead', 'tekgurus' ); ?></h3>
+                            <p class="text-sm leading-relaxed text-gray-200"><?php esc_html_e( 'Explore thought leadership, success stories, and practical guides from TekGurus strategists and engineers.', 'tekgurus' ); ?></p>
+                            <a href="<?php echo esc_url( home_url( '/insights/' ) ); ?>" class="link-more"><?php esc_html_e( 'See latest perspectives', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1 space-y-3">
+                            <a href="<?php echo esc_url( home_url( '/insights/#blogs' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Blogs', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/insights/#news' ) ); ?>" class="submenu-link"><?php esc_html_e( 'News & Events', 'tekgurus' ); ?></a>
+                            <a href="<?php echo esc_url( home_url( '/insights/#cases' ) ); ?>" class="submenu-link"><?php esc_html_e( 'Case Studies', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1">
+                            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero4.svg' ); ?>" alt="<?php esc_attr_e( 'TekGurus insights', 'tekgurus' ); ?>" class="rounded-xl w-full h-full object-cover">
+                        </div>
+                    </div>
+                </div>
+                <div class="mega-menu" data-menu="contact">
+                    <div class="grid grid-cols-4 gap-8">
+                        <div class="col-span-2 space-y-4">
+                            <h3 class="text-2xl font-semibold"><?php esc_html_e( 'Connect with TekGurus', 'tekgurus' ); ?></h3>
+                            <p class="text-sm leading-relaxed text-gray-200"><?php esc_html_e( 'We partner with teams to architect meaningful change. Share your goals and let’s shape the next chapter together.', 'tekgurus' ); ?></p>
+                            <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="link-more"><?php esc_html_e( 'Start a conversation', 'tekgurus' ); ?></a>
+                        </div>
+                        <div class="col-span-1 space-y-3 text-sm">
+                            <p class="submenu-link"><?php esc_html_e( '7 Ibiyinka Olorunbe, VI, Lagos', 'tekgurus' ); ?></p>
+                            <p class="submenu-link"><a href="mailto:info@thetekgurus.com" class="hover:underline">info@thetekgurus.com</a></p>
+                            <p class="submenu-link"><a href="tel:+2349049206989" class="hover:underline">+234 904 920 6989</a></p>
+                        </div>
+                        <div class="col-span-1">
+                            <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero1.svg' ); ?>" alt="<?php esc_attr_e( 'Contact TekGurus', 'tekgurus' ); ?>" class="rounded-xl w-full h-full object-cover">
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</header>
+<div id="mobile-menu" class="fixed inset-0 bg-black/90 backdrop-blur hidden z-40">
+    <div class="px-6 py-8 space-y-8">
+        <div class="flex items-center justify-between">
+            <a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="flex items-center space-x-3">
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/logo/tekgurus-logo.svg' ); ?>" alt="<?php esc_attr_e( 'TekGurus logo', 'tekgurus' ); ?>" class="h-10 w-auto object-contain">
+                <span class="text-lg font-semibold uppercase"><?php bloginfo( 'name' ); ?></span>
+            </a>
+            <button id="mobile-menu-close" aria-label="<?php esc_attr_e( 'Close navigation', 'tekgurus' ); ?>" class="text-light">
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                </svg>
+            </button>
+        </div>
+        <div class="space-y-6">
+            <?php
+            wp_nav_menu(
+                array(
+                    'theme_location' => 'mobile',
+                    'menu_class'     => 'space-y-2 flex flex-col',
+                    'container'      => false,
+                    'fallback_cb'    => 'tekgurus_mobile_menu_fallback',
+                )
+            );
+            ?>
+        </div>
+        <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="btn-primary w-full justify-center"><?php esc_html_e( 'Talk to Our Experts', 'tekgurus' ); ?></a>
+    </div>
+</div>
+<main id="main" class="pt-20">

--- a/tekgurus-theme/js/main.js
+++ b/tekgurus-theme/js/main.js
@@ -1,0 +1,187 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const header = document.querySelector('.site-header');
+    const heroSlides = document.querySelectorAll('.hero-slide');
+    const sliderDotsContainer = document.querySelector('.slider-dots');
+    const sliderControls = document.querySelectorAll('.slider-control');
+    const mobileMenuToggle = document.getElementById('mobile-menu-toggle');
+    const mobileMenuClose = document.getElementById('mobile-menu-close');
+    const mobileMenu = document.getElementById('mobile-menu');
+    const megaMenus = document.querySelectorAll('.mega-menu');
+    const navLinks = document.querySelectorAll('.nav-link');
+    const animateElements = document.querySelectorAll('[data-animate]');
+
+    /* Sticky header */
+    const handleScroll = () => {
+        if (window.scrollY > 40) {
+            header.classList.add('scrolled');
+        } else {
+            header.classList.remove('scrolled');
+        }
+    };
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+
+    /* Hero slider */
+    let currentSlide = 0;
+    let sliderInterval;
+
+    const createDots = () => {
+        if (!sliderDotsContainer || heroSlides.length === 0) return;
+        sliderDotsContainer.innerHTML = '';
+        heroSlides.forEach((_slide, index) => {
+            const dot = document.createElement('button');
+            dot.setAttribute('type', 'button');
+            dot.className = index === 0 ? 'active' : '';
+            dot.addEventListener('click', () => {
+                showSlide(index);
+                restartSlider();
+            });
+            sliderDotsContainer.appendChild(dot);
+        });
+    };
+
+    const updateDots = () => {
+        if (!sliderDotsContainer) return;
+        const dots = sliderDotsContainer.querySelectorAll('button');
+        dots.forEach((dot, index) => {
+            dot.classList.toggle('active', index === currentSlide);
+        });
+    };
+
+    const showSlide = (index) => {
+        if (heroSlides.length === 0) return;
+        currentSlide = (index + heroSlides.length) % heroSlides.length;
+        heroSlides.forEach((slide, slideIndex) => {
+            slide.classList.toggle('active', slideIndex === currentSlide);
+        });
+        updateDots();
+    };
+
+    const nextSlide = () => showSlide(currentSlide + 1);
+    const prevSlide = () => showSlide(currentSlide - 1);
+
+    const startSlider = () => {
+        if (heroSlides.length === 0) return;
+        sliderInterval = setInterval(nextSlide, 7000);
+    };
+
+    const restartSlider = () => {
+        if (!sliderInterval) return;
+        clearInterval(sliderInterval);
+        startSlider();
+    };
+
+    if (heroSlides.length > 0) {
+        heroSlides[0].classList.add('active');
+        createDots();
+        startSlider();
+    }
+
+    sliderControls.forEach(control => {
+        control.addEventListener('click', () => {
+            const direction = control.dataset.direction;
+            if (direction === 'next') {
+                nextSlide();
+            } else {
+                prevSlide();
+            }
+            restartSlider();
+        });
+    });
+
+    /* Mega menu interactions */
+    let megaMenuTimer;
+
+    const hideMegaMenus = () => {
+        megaMenus.forEach(menu => menu.classList.remove('active'));
+        navLinks.forEach(link => link.removeAttribute('aria-expanded'));
+    };
+
+    const openMegaMenu = (target) => {
+        if (!target) return;
+        clearTimeout(megaMenuTimer);
+        megaMenus.forEach(menu => {
+            const isMatch = menu.dataset.menu === target;
+            menu.classList.toggle('active', isMatch);
+        });
+        navLinks.forEach(link => {
+            const expanded = link.dataset.menuTarget === target ? 'true' : 'false';
+            if (expanded === 'true') {
+                link.setAttribute('aria-expanded', 'true');
+            } else {
+                link.removeAttribute('aria-expanded');
+            }
+        });
+    };
+
+    navLinks.forEach(link => {
+        const target = link.dataset.menuTarget;
+        if (!target) return;
+        link.addEventListener('mouseenter', () => openMegaMenu(target));
+        link.addEventListener('focus', () => openMegaMenu(target));
+        link.addEventListener('mouseleave', () => {
+            megaMenuTimer = setTimeout(hideMegaMenus, 250);
+        });
+    });
+
+    megaMenus.forEach(menu => {
+        menu.addEventListener('mouseenter', () => clearTimeout(megaMenuTimer));
+        menu.addEventListener('mouseleave', () => {
+            megaMenuTimer = setTimeout(hideMegaMenus, 150);
+        });
+    });
+
+    document.querySelector('.mega-menu-wrapper')?.addEventListener('mouseleave', () => {
+        megaMenuTimer = setTimeout(hideMegaMenus, 150);
+    });
+
+    document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!target.closest('.site-header')) {
+            hideMegaMenus();
+        }
+    });
+
+    /* Mobile menu */
+    const toggleMobileMenu = (open) => {
+        if (!mobileMenu) return;
+        if (open) {
+            mobileMenu.classList.remove('hidden');
+            document.body.classList.add('overflow-hidden');
+        } else {
+            mobileMenu.classList.add('hidden');
+            document.body.classList.remove('overflow-hidden');
+        }
+    };
+
+    mobileMenuToggle?.addEventListener('click', () => toggleMobileMenu(true));
+    mobileMenuClose?.addEventListener('click', () => toggleMobileMenu(false));
+
+    mobileMenu?.addEventListener('click', (event) => {
+        if (event.target === mobileMenu) {
+            toggleMobileMenu(false);
+        }
+    });
+
+    document.querySelectorAll('#mobile-menu a').forEach(link => {
+        link.addEventListener('click', () => toggleMobileMenu(false));
+    });
+
+    /* Reveal on scroll */
+    if ('IntersectionObserver' in window) {
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, {
+            threshold: 0.2
+        });
+
+        animateElements.forEach(el => observer.observe(el));
+    } else {
+        animateElements.forEach(el => el.classList.add('visible'));
+    }
+});

--- a/tekgurus-theme/page-about.php
+++ b/tekgurus-theme/page-about.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Template for About page.
+ *
+ * @package TekGurus
+ */
+get_header();
+?>
+<section class="relative pt-40 pb-24 bg-cover bg-center" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero2.svg' ); ?>');">
+    <div class="absolute inset-0 bg-black/70"></div>
+    <div class="relative max-w-5xl mx-auto px-6 text-center space-y-6">
+        <p class="eyebrow"><?php esc_html_e( 'About TekGurus', 'tekgurus' ); ?></p>
+        <h1 class="text-4xl md:text-5xl font-semibold"><?php esc_html_e( 'Human-led cloud transformation for Africa’s trailblazers', 'tekgurus' ); ?></h1>
+        <p class="text-lg text-gray-200"><?php esc_html_e( 'TekGurus is a collective of strategists, architects, and change makers dedicated to building intelligent cloud ecosystems that elevate how businesses innovate, scale, and connect.', 'tekgurus' ); ?></p>
+    </div>
+</section>
+<section class="py-24 bg-dark" id="overview">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-center">
+        <div class="space-y-6" data-animate>
+            <p class="eyebrow"><?php esc_html_e( 'Company Overview', 'tekgurus' ); ?></p>
+            <h2 class="section-title"><?php esc_html_e( 'We translate complex cloud ambitions into confident momentum', 'tekgurus' ); ?></h2>
+            <p class="text-gray-300 leading-relaxed"><?php esc_html_e( 'Founded in Lagos, TekGurus partners with organizations across Africa to reimagine cloud experiences. We combine deep industry insight with modern engineering to deliver platforms that are secure, scalable, and centered on people. From strategic advisory to day-to-day operations, we guide teams toward lasting outcomes.', 'tekgurus' ); ?></p>
+            <p class="text-gray-300 leading-relaxed"><?php esc_html_e( 'Our cross-functional squads activate co-creation with clients, embedding best practices while enabling your teams to become future-ready. Each engagement is tailored to your context, ensuring every milestone advances performance, trust, and innovation.', 'tekgurus' ); ?></p>
+        </div>
+        <div class="bg-[#0f0f0f] border border-white/10 rounded-3xl p-10 space-y-6" data-animate>
+            <div>
+                <h3 class="text-2xl font-semibold"><?php esc_html_e( 'Global perspective, African roots', 'tekgurus' ); ?></h3>
+                <p class="text-gray-400 mt-3"><?php esc_html_e( 'We draw from worldwide cloud expertise while honoring the unique opportunities of African markets. Our work bridges regulatory realities, customer behaviors, and emerging ecosystems.', 'tekgurus' ); ?></p>
+            </div>
+            <div>
+                <h3 class="text-2xl font-semibold"><?php esc_html_e( 'Partnership at every stage', 'tekgurus' ); ?></h3>
+                <p class="text-gray-400 mt-3"><?php esc_html_e( 'TekGurus integrates with your teams, aligning leadership, engineering, and operations around shared metrics that accelerate decision making.', 'tekgurus' ); ?></p>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-[#0a0a0a]" id="mission">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-10">
+        <div class="space-y-4" data-animate>
+            <p class="eyebrow"><?php esc_html_e( 'Mission', 'tekgurus' ); ?></p>
+            <h2 class="text-3xl font-semibold"><?php esc_html_e( 'Empower people and platforms to co-create extraordinary value', 'tekgurus' ); ?></h2>
+            <p class="text-gray-300"><?php esc_html_e( 'We exist to help businesses unlock cloud potential with confidence. Through collaborative design, resilient engineering, and guided enablement, we make the cloud work for people—securely and sustainably.', 'tekgurus' ); ?></p>
+        </div>
+        <div class="space-y-4" data-animate>
+            <p class="eyebrow"><?php esc_html_e( 'Vision', 'tekgurus' ); ?></p>
+            <h2 class="text-3xl font-semibold"><?php esc_html_e( 'Inspire Africa’s most trusted cloud-powered enterprises', 'tekgurus' ); ?></h2>
+            <p class="text-gray-300"><?php esc_html_e( 'Our vision is a connected digital continent where organizations move fast, stay protected, and build experiences that matter. TekGurus leads with empathy, intelligence, and accountability to get you there.', 'tekgurus' ); ?></p>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-dark" id="values">
+    <div class="max-w-6xl mx-auto px-6">
+        <div class="section-heading">
+            <p class="eyebrow"><?php esc_html_e( 'Core Values', 'tekgurus' ); ?></p>
+            <h2 class="section-title"><?php esc_html_e( 'The principles that define TekGurus', 'tekgurus' ); ?></h2>
+            <p class="section-description"><?php esc_html_e( 'Our values guide every engagement, ensuring we bring clarity, curiosity, and care to the experiences we co-create.', 'tekgurus' ); ?></p>
+        </div>
+        <div class="grid md:grid-cols-3 gap-8">
+            <div class="card" data-animate>
+                <h3 class="card-title"><?php esc_html_e( 'Innovation', 'tekgurus' ); ?></h3>
+                <p class="card-text"><?php esc_html_e( 'We stay on the frontier of cloud technology, continuously experimenting and translating emerging capabilities into dependable outcomes for clients.', 'tekgurus' ); ?></p>
+            </div>
+            <div class="card" data-animate>
+                <h3 class="card-title"><?php esc_html_e( 'Connection', 'tekgurus' ); ?></h3>
+                <p class="card-text"><?php esc_html_e( 'Relationships power our delivery. We invest in understanding people, cultures, and goals to design solutions that truly resonate.', 'tekgurus' ); ?></p>
+            </div>
+            <div class="card" data-animate>
+                <h3 class="card-title"><?php esc_html_e( 'Inspiration', 'tekgurus' ); ?></h3>
+                <p class="card-text"><?php esc_html_e( 'We encourage bold ideas and empower teams to lead transformation. Every project is an opportunity to inspire new possibilities.', 'tekgurus' ); ?></p>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-[#0a0a0a]" id="leadership">
+    <div class="max-w-6xl mx-auto px-6">
+        <div class="section-heading">
+            <p class="eyebrow"><?php esc_html_e( 'Leadership', 'tekgurus' ); ?></p>
+            <h2 class="section-title"><?php esc_html_e( 'Meet the leaders guiding TekGurus forward', 'tekgurus' ); ?></h2>
+            <p class="section-description"><?php esc_html_e( 'Our leadership blends enterprise experience with startup agility, supporting clients with thoughtful vision and hands-on expertise.', 'tekgurus' ); ?></p>
+        </div>
+        <div class="grid md:grid-cols-3 gap-8">
+            <div class="lead-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/leader1.svg' ); ?>" alt="<?php esc_attr_e( 'Chief Executive Officer', 'tekgurus' ); ?>" class="lead-photo">
+                <div class="p-6 space-y-2">
+                    <h3 class="text-xl font-semibold"><?php esc_html_e( 'Adaobi Martins', 'tekgurus' ); ?></h3>
+                    <p class="text-primary text-sm uppercase tracking-widest"><?php esc_html_e( 'Chief Executive Officer', 'tekgurus' ); ?></p>
+                    <p class="text-gray-300 text-sm leading-relaxed"><?php esc_html_e( 'Adaobi champions TekGurus’ mission to humanize technology adoption, guiding enterprise leaders through cloud transformation journeys.', 'tekgurus' ); ?></p>
+                </div>
+            </div>
+            <div class="lead-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/leader2.svg' ); ?>" alt="<?php esc_attr_e( 'Chief Technology Officer', 'tekgurus' ); ?>" class="lead-photo">
+                <div class="p-6 space-y-2">
+                    <h3 class="text-xl font-semibold"><?php esc_html_e( 'Kunle Adebayo', 'tekgurus' ); ?></h3>
+                    <p class="text-primary text-sm uppercase tracking-widest"><?php esc_html_e( 'Chief Technology Officer', 'tekgurus' ); ?></p>
+                    <p class="text-gray-300 text-sm leading-relaxed"><?php esc_html_e( 'Kunle architects secure, scalable platforms across multi-cloud environments, driving technical excellence and automation strategies.', 'tekgurus' ); ?></p>
+                </div>
+            </div>
+            <div class="lead-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/leader3.svg' ); ?>" alt="<?php esc_attr_e( 'Chief Experience Officer', 'tekgurus' ); ?>" class="lead-photo">
+                <div class="p-6 space-y-2">
+                    <h3 class="text-xl font-semibold"><?php esc_html_e( 'Tosin Ayoola', 'tekgurus' ); ?></h3>
+                    <p class="text-primary text-sm uppercase tracking-widest"><?php esc_html_e( 'Chief Experience Officer', 'tekgurus' ); ?></p>
+                    <p class="text-gray-300 text-sm leading-relaxed"><?php esc_html_e( 'Tosin ensures every TekGurus engagement delivers value to people first, orchestrating change management and enablement programs.', 'tekgurus' ); ?></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-dark" id="approach">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+        <div class="space-y-6" data-animate>
+            <p class="eyebrow"><?php esc_html_e( 'Our Approach', 'tekgurus' ); ?></p>
+            <h2 class="section-title"><?php esc_html_e( 'Co-creating resilient, insight-driven cloud ecosystems', 'tekgurus' ); ?></h2>
+            <p class="text-gray-300 leading-relaxed"><?php esc_html_e( 'TekGurus begins every engagement with discovery workshops that clarify the needs of your customers, teams, and stakeholders. We translate insights into blueprints that prioritize security, compliance, and accelerated delivery.', 'tekgurus' ); ?></p>
+            <p class="text-gray-300 leading-relaxed"><?php esc_html_e( 'Our iterative approach means we launch quickly, learn fast, and continually optimize. Continuous enablement keeps your teams empowered long after launch.', 'tekgurus' ); ?></p>
+        </div>
+        <div class="space-y-6" data-animate>
+            <div class="approach-step">
+                <span class="step-index">01</span>
+                <div>
+                    <h3 class="text-xl font-semibold"><?php esc_html_e( 'Discover & Align', 'tekgurus' ); ?></h3>
+                    <p class="text-gray-300 mt-2"><?php esc_html_e( 'We engage stakeholders to map business priorities, technical readiness, and success metrics.', 'tekgurus' ); ?></p>
+                </div>
+            </div>
+            <div class="approach-step">
+                <span class="step-index">02</span>
+                <div>
+                    <h3 class="text-xl font-semibold"><?php esc_html_e( 'Design & Engineer', 'tekgurus' ); ?></h3>
+                    <p class="text-gray-300 mt-2"><?php esc_html_e( 'Our teams prototype and build modern architectures with automation, observability, and governance baked in.', 'tekgurus' ); ?></p>
+                </div>
+            </div>
+            <div class="approach-step">
+                <span class="step-index">03</span>
+                <div>
+                    <h3 class="text-xl font-semibold"><?php esc_html_e( 'Enable & Evolve', 'tekgurus' ); ?></h3>
+                    <p class="text-gray-300 mt-2"><?php esc_html_e( 'We upskill teams, transition operations seamlessly, and iterate through continuous improvement cycles.', 'tekgurus' ); ?></p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<?php
+get_footer();

--- a/tekgurus-theme/page-contact.php
+++ b/tekgurus-theme/page-contact.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Template for Contact page.
+ *
+ * @package TekGurus
+ */
+get_header();
+?>
+<section class="relative pt-40 pb-24 bg-cover bg-center" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero2.svg' ); ?>');">
+    <div class="absolute inset-0 bg-black/75"></div>
+    <div class="relative max-w-4xl mx-auto px-6 text-center space-y-6">
+        <p class="eyebrow">Contact TekGurus</p>
+        <h1 class="text-4xl md:text-5xl font-semibold">Let’s co-create the next evolution of your cloud journey</h1>
+        <p class="text-lg text-gray-200">Share your goals and challenges. Our experts will collaborate with you to define the path forward—whether it’s modernization, automation, or managed services.</p>
+    </div>
+</section>
+<section class="py-24 bg-dark">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12">
+        <div class="space-y-6" data-animate>
+            <p class="eyebrow">Talk to Our Experts</p>
+            <h2 class="section-title">We’re ready to listen and lead together</h2>
+            <p class="text-gray-300 leading-relaxed">Tell us about your current initiatives, desired outcomes, and timelines. A TekGurus consultant will reach out to craft a tailored engagement plan.</p>
+            <div class="bg-[#0f0f0f] border border-white/10 rounded-3xl p-8 space-y-4">
+                <p class="flex items-center space-x-3 text-gray-300"><span class="contact-icon">📍</span><span>7 Ibiyinka Olorunbe, VI, Lagos, Nigeria</span></p>
+                <p class="flex items-center space-x-3 text-gray-300"><span class="contact-icon">✉️</span><a href="mailto:info@thetekgurus.com" class="hover:text-primary">info@thetekgurus.com</a></p>
+                <p class="flex items-center space-x-3 text-gray-300"><span class="contact-icon">📞</span><a href="tel:+2349049206989" class="hover:text-primary">+234 904 920 6989</a></p>
+            </div>
+            <div class="grid grid-cols-2 gap-6 text-gray-300 text-sm">
+                <div>
+                    <h3 class="text-lg font-semibold text-light">Office Hours</h3>
+                    <p class="mt-2 text-gray-400">Monday – Friday<br>09:00 – 18:00 (WAT)</p>
+                </div>
+                <div>
+                    <h3 class="text-lg font-semibold text-light">Follow TekGurus</h3>
+                    <p class="mt-2 text-gray-400">LinkedIn · Twitter · Instagram · YouTube</p>
+                </div>
+            </div>
+        </div>
+        <form class="bg-[#0f0f0f] border border-white/10 rounded-3xl p-8 space-y-6" data-animate>
+            <div class="grid md:grid-cols-2 gap-6">
+                <div>
+                    <label class="form-label" for="name">Full Name</label>
+                    <input id="name" type="text" class="form-input" placeholder="Jane Doe" required>
+                </div>
+                <div>
+                    <label class="form-label" for="email">Work Email</label>
+                    <input id="email" type="email" class="form-input" placeholder="you@company.com" required>
+                </div>
+            </div>
+            <div class="grid md:grid-cols-2 gap-6">
+                <div>
+                    <label class="form-label" for="company">Company</label>
+                    <input id="company" type="text" class="form-input" placeholder="Your organization" required>
+                </div>
+                <div>
+                    <label class="form-label" for="phone">Phone</label>
+                    <input id="phone" type="tel" class="form-input" placeholder="+234 000 000 0000">
+                </div>
+            </div>
+            <div>
+                <label class="form-label" for="interest">How can we help?</label>
+                <select id="interest" class="form-input" required>
+                    <option value="" disabled selected>Select an option</option>
+                    <option>Cloud Strategy &amp; Advisory</option>
+                    <option>Implementation &amp; Migration</option>
+                    <option>Security &amp; Governance</option>
+                    <option>Optimization &amp; Automation</option>
+                    <option>Managed Services</option>
+                    <option>Training &amp; Enablement</option>
+                </select>
+            </div>
+            <div>
+                <label class="form-label" for="message">Project Details</label>
+                <textarea id="message" rows="4" class="form-input" placeholder="Share goals, timelines, and success measures"></textarea>
+            </div>
+            <button type="submit" class="btn-primary w-full justify-center">Submit Request</button>
+            <p class="text-xs text-gray-500">By submitting this form you agree to receive communications from TekGurus. You may unsubscribe at any time.</p>
+        </form>
+    </div>
+</section>
+<section class="py-24 bg-[#0a0a0a]">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-center">
+        <div class="space-y-6" data-animate>
+            <p class="eyebrow">Visit Us</p>
+            <h2 class="section-title">Our Lagos headquarters</h2>
+            <p class="text-gray-300">We’re located in the heart of Victoria Island with collaboration spaces designed for innovation workshops, training sessions, and executive briefings.</p>
+            <a href="mailto:info@thetekgurus.com" class="btn-secondary inline-flex">Schedule an onsite session</a>
+        </div>
+        <div class="relative h-80 rounded-3xl overflow-hidden border border-white/10" data-animate>
+            <div class="absolute inset-0 bg-black/70 flex items-center justify-center text-gray-400">
+                <p>Google Map placeholder – embed map here</p>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-gradient-to-br from-primary/80 to-black">
+    <div class="max-w-4xl mx-auto px-6 text-center space-y-6" data-animate>
+        <h2 class="text-3xl md:text-4xl font-semibold">Partner with TekGurus today</h2>
+        <p class="text-lg text-gray-100">Our experts are ready to help you modernize infrastructure, launch new products, and empower your teams.</p>
+        <div class="flex flex-wrap justify-center gap-4">
+            <a href="tel:+2349049206989" class="btn-primary">Call us</a>
+            <a href="mailto:info@thetekgurus.com" class="btn-secondary">Email TekGurus</a>
+        </div>
+    </div>
+</section>
+<?php
+get_footer();

--- a/tekgurus-theme/page-insights.php
+++ b/tekgurus-theme/page-insights.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Template for Insights page.
+ *
+ * @package TekGurus
+ */
+get_header();
+?>
+<section class="relative pt-40 pb-24 bg-cover bg-center" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero1.svg' ); ?>');">
+    <div class="absolute inset-0 bg-black/70"></div>
+    <div class="relative max-w-5xl mx-auto px-6 text-center space-y-6">
+        <p class="eyebrow">TekGurus Insights</p>
+        <h1 class="text-4xl md:text-5xl font-semibold">Ideas, stories, and playbooks for cloud-forward teams</h1>
+        <p class="text-lg text-gray-200">Stay ahead with perspectives from TekGurus strategists and engineers on modern architectures, change leadership, and the future of digital experiences.</p>
+    </div>
+</section>
+<section class="py-24 bg-dark" id="blogs">
+    <div class="max-w-6xl mx-auto px-6">
+        <div class="section-heading">
+            <p class="eyebrow">Latest Blogs</p>
+            <h2 class="section-title">Practical guidance for your next move</h2>
+            <p class="section-description">Explore step-by-step recommendations, engineering playbooks, and leadership perspectives shaped by real-world engagements.</p>
+        </div>
+        <div class="grid gap-10 md:grid-cols-3">
+            <article class="insight-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/insight1.svg' ); ?>" alt="Blog" class="insight-image">
+                <div class="p-6 space-y-3">
+                    <p class="text-xs uppercase tracking-widest text-primary">Cloud Strategy</p>
+                    <h3 class="text-2xl font-semibold">Designing a resilient multi-cloud foundation</h3>
+                    <p class="text-gray-300 text-sm leading-relaxed">Learn how TekGurus maps governance and automation to align multi-cloud adoption with business priorities.</p>
+                    <a href="#" class="link-more">Read Story</a>
+                </div>
+            </article>
+            <article class="insight-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/insight2.svg' ); ?>" alt="Blog" class="insight-image">
+                <div class="p-6 space-y-3">
+                    <p class="text-xs uppercase tracking-widest text-primary">Automation</p>
+                    <h3 class="text-2xl font-semibold">Elevating DevOps with AI copilots</h3>
+                    <p class="text-gray-300 text-sm leading-relaxed">Discover how intelligent tooling accelerates releases, improves quality, and enhances developer experience.</p>
+                    <a href="#" class="link-more">Read Story</a>
+                </div>
+            </article>
+            <article class="insight-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/insight3.svg' ); ?>" alt="Blog" class="insight-image">
+                <div class="p-6 space-y-3">
+                    <p class="text-xs uppercase tracking-widest text-primary">People &amp; Change</p>
+                    <h3 class="text-2xl font-semibold">Building a culture of cloud fluency</h3>
+                    <p class="text-gray-300 text-sm leading-relaxed">Strategies for equipping teams with the skills, rituals, and mindset needed to sustain cloud transformation.</p>
+                    <a href="#" class="link-more">Read Story</a>
+                </div>
+            </article>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-[#0a0a0a]" id="news">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-center">
+        <div class="space-y-6" data-animate>
+            <p class="eyebrow">News &amp; Events</p>
+            <h2 class="section-title">Highlights from the TekGurus community</h2>
+            <p class="text-gray-300">Follow our latest partnerships, product releases, and community engagements as we collaborate with innovators across the continent.</p>
+            <ul class="space-y-4 text-gray-300">
+                <li class="flex items-start space-x-3"><span class="text-primary mt-1">▹</span><span>TekGurus announces strategic partnership with regional fintech consortium.</span></li>
+                <li class="flex items-start space-x-3"><span class="text-primary mt-1">▹</span><span>Upcoming webinar: Accelerating public sector digitization with secure cloud.</span></li>
+                <li class="flex items-start space-x-3"><span class="text-primary mt-1">▹</span><span>Innovation lab recap: Co-creating data platforms for smart campuses.</span></li>
+            </ul>
+        </div>
+        <div class="grid gap-8" data-animate>
+            <article class="news-card">
+                <h3 class="text-xl font-semibold">Webinar • April 2025</h3>
+                <p class="text-gray-300 mt-2">Join TekGurus experts as we unpack hybrid operations models for regulated industries.</p>
+                <a href="#" class="link-more">Save your seat</a>
+            </article>
+            <article class="news-card">
+                <h3 class="text-xl font-semibold">Event • May 2025</h3>
+                <p class="text-gray-300 mt-2">Meet us at the Lagos Digital Transformation Summit to explore real-world case studies.</p>
+                <a href="#" class="link-more">Book a meeting</a>
+            </article>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-dark" id="cases">
+    <div class="max-w-6xl mx-auto px-6">
+        <div class="section-heading">
+            <p class="eyebrow">Case Studies</p>
+            <h2 class="section-title">Proof of what’s possible with TekGurus</h2>
+            <p class="section-description">Our engagements show how collaborative cloud strategies lead to measurable outcomes. Explore stories from finance, education, startups, and the public sector.</p>
+        </div>
+        <div class="grid gap-10 md:grid-cols-3">
+            <article class="insight-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/insight4.svg' ); ?>" alt="Case Study" class="insight-image">
+                <div class="p-6 space-y-3">
+                    <p class="text-xs uppercase tracking-widest text-primary">Financial Services</p>
+                    <h3 class="text-2xl font-semibold">Securing digital payments infrastructure</h3>
+                    <p class="text-gray-300 text-sm leading-relaxed">How a fintech scaled securely across regions with TekGurus’ zero-trust architecture and DevSecOps support.</p>
+                    <a href="#" class="link-more">View Case</a>
+                </div>
+            </article>
+            <article class="insight-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/insight5.svg' ); ?>" alt="Case Study" class="insight-image">
+                <div class="p-6 space-y-3">
+                    <p class="text-xs uppercase tracking-widest text-primary">Education</p>
+                    <h3 class="text-2xl font-semibold">Modernizing learning experiences</h3>
+                    <p class="text-gray-300 text-sm leading-relaxed">A leading university partnered with TekGurus to launch a resilient digital campus powered by cloud-native services.</p>
+                    <a href="#" class="link-more">View Case</a>
+                </div>
+            </article>
+            <article class="insight-card" data-animate>
+                <img src="<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/insight6.svg' ); ?>" alt="Case Study" class="insight-image">
+                <div class="p-6 space-y-3">
+                    <p class="text-xs uppercase tracking-widest text-primary">Public Sector</p>
+                    <h3 class="text-2xl font-semibold">Transforming citizen services</h3>
+                    <p class="text-gray-300 text-sm leading-relaxed">Discover how we helped a government agency digitize services with secure workflows and data-driven insights.</p>
+                    <a href="#" class="link-more">View Case</a>
+                </div>
+            </article>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-gradient-to-br from-primary/80 to-black">
+    <div class="max-w-4xl mx-auto px-6 text-center space-y-6" data-animate>
+        <h2 class="text-3xl md:text-4xl font-semibold">Stay inspired with TekGurus insights</h2>
+        <p class="text-lg text-gray-100">Subscribe to our newsletter for curated articles, event invites, and exclusive tools to power your cloud initiatives.</p>
+        <form class="flex flex-col md:flex-row items-center justify-center gap-4 max-w-3xl mx-auto">
+            <input type="email" placeholder="Your email address" class="w-full md:flex-1 px-5 py-3 rounded-full bg-black/70 border border-white/20 text-white focus:outline-none focus:border-primary" required>
+            <button type="submit" class="btn-primary">Subscribe</button>
+        </form>
+    </div>
+</section>
+<?php
+get_footer();

--- a/tekgurus-theme/page-services.php
+++ b/tekgurus-theme/page-services.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Template for Services page.
+ *
+ * @package TekGurus
+ */
+get_header();
+?>
+<section class="relative pt-40 pb-24 bg-cover bg-center" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero3.svg' ); ?>');">
+    <div class="absolute inset-0 bg-black/75"></div>
+    <div class="relative max-w-5xl mx-auto px-6 text-center space-y-6">
+        <p class="eyebrow">Our Services</p>
+        <h1 class="text-4xl md:text-5xl font-semibold">Cloud services designed to launch, scale, and sustain innovation</h1>
+        <p class="text-lg text-gray-200">TekGurus provides end-to-end expertise—from strategy and migration to automation and enablement—so your teams can innovate with clarity and confidence.</p>
+    </div>
+</section>
+<section class="py-24 bg-dark">
+    <div class="max-w-6xl mx-auto px-6 grid gap-10 md:grid-cols-2 xl:grid-cols-3">
+        <article class="service-card" id="strategy" data-animate>
+            <div class="service-icon">01</div>
+            <h3 class="service-title">Cloud Strategy &amp; Advisory</h3>
+            <p class="service-text">Shape a visionary yet pragmatic roadmap that aligns cloud investments with business outcomes. We assess readiness, design governance, and prioritize initiatives that deliver measurable value.</p>
+            <a href="#strategy" class="service-link">Learn More</a>
+        </article>
+        <article class="service-card" id="implementation" data-animate>
+            <div class="service-icon">02</div>
+            <h3 class="service-title">Cloud Implementation &amp; Migration</h3>
+            <p class="service-text">Execute migrations with minimal disruption. TekGurus architects resilient landing zones, modernizes applications, and orchestrates data movement with security at the center.</p>
+            <a href="#implementation" class="service-link">Learn More</a>
+        </article>
+        <article class="service-card" id="security" data-animate>
+            <div class="service-icon">03</div>
+            <h3 class="service-title">Cloud Security &amp; Governance</h3>
+            <p class="service-text">Implement zero-trust architectures, compliance controls, and identity frameworks that keep your ecosystems protected without slowing innovation.</p>
+            <a href="#security" class="service-link">Learn More</a>
+        </article>
+        <article class="service-card" id="optimization" data-animate>
+            <div class="service-icon">04</div>
+            <h3 class="service-title">Cloud Optimization &amp; Automation</h3>
+            <p class="service-text">Leverage AI-driven insights, FinOps practices, and infrastructure-as-code to reduce costs, enhance performance, and accelerate delivery cycles.</p>
+            <a href="#optimization" class="service-link">Learn More</a>
+        </article>
+        <article class="service-card" id="managed" data-animate>
+            <div class="service-icon">05</div>
+            <h3 class="service-title">Managed Cloud Services</h3>
+            <p class="service-text">Gain peace of mind with proactive monitoring, incident response, and lifecycle management tailored to your SLAs and business rhythms.</p>
+            <a href="#managed" class="service-link">Learn More</a>
+        </article>
+        <article class="service-card" id="training" data-animate>
+            <div class="service-icon">06</div>
+            <h3 class="service-title">Cloud Training &amp; Enablement</h3>
+            <p class="service-text">Upskill your teams with immersive workshops, certification pathways, and embedded coaching that build lasting cloud fluency.</p>
+            <a href="#training" class="service-link">Learn More</a>
+        </article>
+    </div>
+</section>
+<section class="py-24 bg-[#0a0a0a]">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-center">
+        <div class="space-y-6" data-animate>
+            <p class="eyebrow">How We Deliver</p>
+            <h2 class="section-title">Integrated teams that move from blueprint to impact</h2>
+            <p class="text-gray-300 leading-relaxed">TekGurus squads blend strategy consultants, solution architects, security experts, and change managers. We work side-by-side with your teams to execute with precision and transfer knowledge throughout the engagement.</p>
+            <div class="space-y-4">
+                <div class="approach-step">
+                    <span class="step-index">1</span>
+                    <div>
+                        <h3 class="text-lg font-semibold">Collaborative Planning</h3>
+                        <p class="text-gray-300 mt-1">Vision workshops translate ambition into phased roadmaps with prioritized milestones.</p>
+                    </div>
+                </div>
+                <div class="approach-step">
+                    <span class="step-index">2</span>
+                    <div>
+                        <h3 class="text-lg font-semibold">Engineering Excellence</h3>
+                        <p class="text-gray-300 mt-1">Automation-first builds, reusable accelerators, and DevSecOps pipelines keep delivery fast and secure.</p>
+                    </div>
+                </div>
+                <div class="approach-step">
+                    <span class="step-index">3</span>
+                    <div>
+                        <h3 class="text-lg font-semibold">Continuous Enablement</h3>
+                        <p class="text-gray-300 mt-1">Enablement playbooks, pairing sessions, and managed services ensure value long after go-live.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="bg-[#111111] border border-white/10 rounded-3xl p-10 space-y-6" data-animate>
+            <h3 class="text-2xl font-semibold">Outcomes you can expect</h3>
+            <ul class="space-y-4 text-gray-300">
+                <li class="flex items-start space-x-3"><span class="text-primary mt-1">▹</span><span>Accelerated modernization of critical workloads through proven patterns.</span></li>
+                <li class="flex items-start space-x-3"><span class="text-primary mt-1">▹</span><span>Improved operational resilience with observability and automated remediation.</span></li>
+                <li class="flex items-start space-x-3"><span class="text-primary mt-1">▹</span><span>Empowered teams ready to manage, optimize, and evolve your cloud estate.</span></li>
+            </ul>
+            <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="btn-secondary inline-flex">Schedule a strategy session</a>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-gradient-to-br from-primary/80 to-black">
+    <div class="max-w-5xl mx-auto px-6 text-center space-y-6" data-animate>
+        <h2 class="text-3xl md:text-4xl font-semibold">Ready to ignite your next cloud initiative?</h2>
+        <p class="text-lg text-gray-100">TekGurus partners with enterprises, scale-ups, and public sector innovators to design cloud programs that fuel progress. Let’s craft a roadmap built around your goals.</p>
+        <div class="flex flex-wrap justify-center gap-4">
+            <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="btn-primary">Talk to TekGurus</a>
+            <a href="<?php echo esc_url( home_url( '/insights/' ) ); ?>" class="btn-secondary">Explore our insights</a>
+        </div>
+    </div>
+</section>
+<?php
+get_footer();

--- a/tekgurus-theme/page-solutions.php
+++ b/tekgurus-theme/page-solutions.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Template for Solutions page.
+ *
+ * @package TekGurus
+ */
+get_header();
+?>
+<section class="relative pt-40 pb-24 bg-cover bg-center" style="background-image: url('<?php echo esc_url( TEKGURUS_THEME_URI . '/assets/images/hero4.svg' ); ?>');">
+    <div class="absolute inset-0 bg-black/75"></div>
+    <div class="relative max-w-5xl mx-auto px-6 text-center space-y-6">
+        <p class="eyebrow">Our Solutions</p>
+        <h1 class="text-4xl md:text-5xl font-semibold">Architecting intelligent solutions for a connected future</h1>
+        <p class="text-lg text-gray-200">TekGurus designs cloud solutions that balance performance, security, and agility. We align technology stacks with industry realities, unlocking transformative experiences across sectors.</p>
+    </div>
+</section>
+<section class="py-24 bg-dark">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-start">
+        <div class="space-y-6" data-animate>
+            <p class="eyebrow">Solution Domains</p>
+            <h2 class="section-title">Bringing clarity to complex challenges</h2>
+            <p class="text-gray-300 leading-relaxed">Every solution is engineered with resilience, observability, and scale in mind. TekGurus leverages hyperscaler services, automation frameworks, and AI-driven insight to transform how organizations operate and serve customers.</p>
+            <div class="grid gap-6">
+                <div class="solution-highlight">
+                    <h3 class="text-xl font-semibold">Human-centered innovation</h3>
+                    <p class="text-gray-300">We co-design with stakeholders to ensure adoption, accessibility, and meaningful change.</p>
+                </div>
+                <div class="solution-highlight">
+                    <h3 class="text-xl font-semibold">Security and compliance assured</h3>
+                    <p class="text-gray-300">Industry-specific guardrails and governance frameworks protect your data and reputation.</p>
+                </div>
+            </div>
+        </div>
+        <div class="space-y-8" data-animate>
+            <article class="solution-card" id="hybrid">
+                <h3 class="text-2xl font-semibold">Hybrid &amp; Multi-Cloud Solutions</h3>
+                <p class="text-gray-300 mt-3">Design unified platforms across on-premises and cloud environments. TekGurus enables seamless workload portability, centralized management, and resilient connectivity across clouds.</p>
+                <ul class="solution-list">
+                    <li>Landing zones and cloud centers of excellence</li>
+                    <li>Interoperability and network architecture design</li>
+                    <li>Compliance-driven governance models</li>
+                </ul>
+            </article>
+            <article class="solution-card" id="automation">
+                <h3 class="text-2xl font-semibold">AI-Powered Automation</h3>
+                <p class="text-gray-300 mt-3">Amplify productivity with intelligent automation. We deploy AI/ML workflows, event-driven architectures, and smart assistants to streamline operations and decision making.</p>
+                <ul class="solution-list">
+                    <li>Automation strategy and ROI mapping</li>
+                    <li>ML Ops and data pipeline modernization</li>
+                    <li>AI-infused support experiences</li>
+                </ul>
+            </article>
+            <article class="solution-card" id="analytics">
+                <h3 class="text-2xl font-semibold">Data Analytics &amp; Insights</h3>
+                <p class="text-gray-300 mt-3">Unlock reliable data intelligence with modern platforms. TekGurus builds unified data estates, real-time dashboards, and predictive models that empower confident decisions.</p>
+                <ul class="solution-list">
+                    <li>Data lakes, warehouses, and lakehouse patterns</li>
+                    <li>Self-service analytics and BI enablement</li>
+                    <li>Advanced analytics and visualization</li>
+                </ul>
+            </article>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-[#0a0a0a]">
+    <div class="max-w-6xl mx-auto px-6 grid lg:grid-cols-2 gap-12 items-center">
+        <div class="space-y-8" data-animate>
+            <article class="solution-card" id="transformation">
+                <h3 class="text-2xl font-semibold">Digital Transformation Support</h3>
+                <p class="text-gray-300 mt-3">Guide cross-functional change with a structured approach that brings technology, people, and processes into alignment. We develop modernization programs that elevate customer experience and operational efficiency.</p>
+                <ul class="solution-list">
+                    <li>Transformation governance and PMO support</li>
+                    <li>Design thinking and product strategy sprints</li>
+                    <li>Change management and enablement</li>
+                </ul>
+            </article>
+            <article class="solution-card" id="industry">
+                <h3 class="text-2xl font-semibold">Industry Solutions</h3>
+                <p class="text-gray-300 mt-3">We tailor frameworks for financial services, education, startups, and the public sector—anchored in compliance, security, and agility.</p>
+                <ul class="solution-list">
+                    <li>Regulatory-aligned cloud platforms for finance</li>
+                    <li>Digital learning ecosystems for education</li>
+                    <li>Launchpads for startups and innovation hubs</li>
+                    <li>Civic services modernization for government</li>
+                </ul>
+            </article>
+        </div>
+        <div class="bg-[#111111] border border-white/10 rounded-3xl p-10 space-y-6" data-animate>
+            <h3 class="text-2xl font-semibold">Why TekGurus solutions scale</h3>
+            <p class="text-gray-300">Our modular blueprints, automation libraries, and DevSecOps culture ensure rapid delivery without compromising safety.</p>
+            <div class="grid grid-cols-2 gap-6 text-sm text-gray-300">
+                <div>
+                    <h4 class="font-semibold text-light">Accelerated Deployment</h4>
+                    <p class="mt-2 text-gray-400">Reusable assets cut delivery time while preserving quality.</p>
+                </div>
+                <div>
+                    <h4 class="font-semibold text-light">Lifecycle Partnership</h4>
+                    <p class="mt-2 text-gray-400">We iterate alongside your teams to optimize performance and adoption.</p>
+                </div>
+                <div>
+                    <h4 class="font-semibold text-light">Insight-Driven Decisions</h4>
+                    <p class="mt-2 text-gray-400">Observability and analytics keep leadership informed in real time.</p>
+                </div>
+                <div>
+                    <h4 class="font-semibold text-light">Security Embedded</h4>
+                    <p class="mt-2 text-gray-400">Guardrails and policy-as-code uphold compliance across industries.</p>
+                </div>
+            </div>
+            <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="btn-secondary inline-flex">Discuss your solution</a>
+        </div>
+    </div>
+</section>
+<section class="py-24 bg-gradient-to-br from-primary/80 to-black">
+    <div class="max-w-5xl mx-auto px-6 text-center space-y-6" data-animate>
+        <h2 class="text-3xl md:text-4xl font-semibold">Let’s unlock your next horizon</h2>
+        <p class="text-lg text-gray-100">Connect with TekGurus to design a roadmap tailored to your industry, customers, and strategic goals. Together we’ll build a resilient, intelligent cloud ecosystem.</p>
+        <div class="flex flex-wrap justify-center gap-4">
+            <a href="<?php echo esc_url( home_url( '/contact/' ) ); ?>" class="btn-primary">Start a conversation</a>
+            <a href="<?php echo esc_url( home_url( '/services/' ) ); ?>" class="btn-secondary">View our services</a>
+        </div>
+    </div>
+</section>
+<?php
+get_footer();

--- a/tekgurus-theme/page.php
+++ b/tekgurus-theme/page.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Default page template.
+ *
+ * @package TekGurus
+ */
+get_header();
+?>
+<div class="max-w-4xl mx-auto px-6 py-16 content-area">
+    <?php
+    if ( have_posts() ) {
+        while ( have_posts() ) {
+            the_post();
+            the_content();
+        }
+    }
+    ?>
+</div>
+<?php
+get_footer();

--- a/tekgurus-theme/style.css
+++ b/tekgurus-theme/style.css
@@ -1,0 +1,12 @@
+/*
+Theme Name: TekGurus
+Theme URI: https://thetekgurus.com/
+Author: TekGurus
+Description: WordPress theme conversion of the TekGurus static site with Bricks Builder support.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: tekgurus
+*/
+
+@import url("css/style.css");


### PR DESCRIPTION
## Summary
- add a TekGurus WordPress theme that mirrors the existing static site styling and assets
- enqueue Tailwind, fonts, and theme scripts while registering menus and Bricks Builder locations
- provide page templates for the landing page plus About, Services, Solutions, Insights, and Contact layouts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6903ee8775c88333aedc6228e80abe2d